### PR TITLE
[Fix] python manage.py const実行時に生成されなかったり,正しくないファイルがあるバグを解消

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+# 注意事項 / Warning
+このリポジトリは[izumin2000/subekashi](https://github.com/izumin2000/subekashi)のフォークリポジトリです。
+有益な情報を得たい場合はそちらをご覧ください。
+This repogitory is fork of [izumin2000/subekashi](https://github.com/izumin2000/subekashi).
+If you need infomation, Then see original repogitory.
+
+
 # 全て歌詞の所為です。とは  
 『全て歌詞の所為です。』とは「[界隈曲](https://dic.nicovideo.jp/a/%E7%95%8C%E9%9A%88%E6%9B%B2)」と呼ばれる音楽ジャンルに焦点を当てた界隈曲情報掲載サイトです。  
 以下のような機能があります。

--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-# 注意事項 / Warning
-このリポジトリは[izumin2000/subekashi](https://github.com/izumin2000/subekashi)のフォークリポジトリです。
-有益な情報を得たい場合はそちらをご覧ください。
-This repogitory is fork of [izumin2000/subekashi](https://github.com/izumin2000/subekashi).
-If you need infomation, Then see original repogitory.
-
-
 # 全て歌詞の所為です。とは  
 『全て歌詞の所為です。』とは「[界隈曲](https://dic.nicovideo.jp/a/%E7%95%8C%E9%9A%88%E6%9B%B2)」と呼ばれる音楽ジャンルに焦点を当てた界隈曲情報掲載サイトです。  
 以下のような機能があります。

--- a/subekashi/management/commands/const.py
+++ b/subekashi/management/commands/const.py
@@ -12,8 +12,9 @@ class Command(BaseCommand):
             'ai.py': 'GENEINFO = {\n\t"WORD_COUNT": 1440480,\n\t"SONG_COUNT": 3000,\n\t"GENE_DATE": "2024年9月9日",\n}',
             'ban.py': 'BAN_LIST = []',
             'gpt.txt': '',
-            'version.json': 'VERSION = "dev"',
+            'version.json': '{"VERSION":"dev"}',
             'reject.py': 'REJECT_LIST = []',
+            'news.md':''
         }
         for file_name, text in CONST_INFO.items():
             const_path = os.path.join(BASE_DIR, 'subekashi/constants/dynamic', file_name)

--- a/subekashi/management/commands/const.py
+++ b/subekashi/management/commands/const.py
@@ -14,7 +14,7 @@ class Command(BaseCommand):
             'gpt.txt': '',
             'version.json': '{"VERSION":"dev"}',
             'reject.py': 'REJECT_LIST = []',
-            'news.md':''
+            'news.md':'subekashi/constants/dynamic/news.mdにニュースを追加してください'
         }
         for file_name, text in CONST_INFO.items():
             const_path = os.path.join(BASE_DIR, 'subekashi/constants/dynamic', file_name)


### PR DESCRIPTION
(gitの仕様に慣れてなかったせいでREADME.mdにコミットが入ってしまっているのは申し訳ありません)
`python manage.py const`実行時に生成される`version.json`が正しいJSON形式で出力されずに、サイトアクセス時にエラーが発生するバグを修正するため、`version.json`が正しいJSON形式で出力されるように変更します。
また、本来生成されるべき`news.md`が生成されないバグを修正しました。
また、`news.md`生成時
```
subekashi/constants/dynamic/news.mdにニュースを追加してください
```
がデフォルト値として設定してあります