### PR TITLE
[Fix] 歌詞にHTMLやJavaScriptなどを埋め込める重大バグの修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ static/
 sessions/*
 !sessions/
 !sessions/.gitkeep
+.vscode
+.prettierrc
+subekashi/static/subekashi/special/*.mp3

--- a/subekashi/templatetags/song_card.py
+++ b/subekashi/templatetags/song_card.py
@@ -18,6 +18,8 @@ def get_channel(song):
         return mark_safe('<i class="fas fa-user-friends"></i>合作')
     # 単作なら
     channel = channels[0]
+    # html特殊文字をエスケープ(一応)
+    channel = channel.replace("&","&amp;").replace("<","&lt;").replace(">","&gt;")
     channel_url = reverse('subekashi:channel', args=[channel])
     return mark_safe(f'<object><a href="{channel_url}"><i class="fas fa-user-circle"></i>{channel}</a></object>')
 
@@ -70,7 +72,8 @@ def get_url(song):
 @register.simple_tag
 def get_lyrics(song):
     lyrics = song.lyrics[:50]
-    
+    # html特殊文字をエスケープ
+    lyrics=lyrics.replace("&","&amp;").replace("<","&lt;").replace(">","&gt;")
     # インスト曲なら
     if not lyrics and song.isinst:
         return mark_safe('<i class="fas fa-align-center"></i>インスト曲')

--- a/subekashi/views/song.py
+++ b/subekashi/views/song.py
@@ -43,13 +43,15 @@ def song(request, song_id):
     
     # 歌詞のHTML化
     br_lyrics = request.COOKIES.get("brlyrics", "normal")
+    # html特殊文字をエスケープ
+    html_lyrics = song.lyrics.replace("&","&amp;").replace("<","&lt;").replace(">","&gt;")
     if br_lyrics == "normal":
-        html_lyrics = song.lyrics.replace("\n", "<br>")
+        html_lyrics = html_lyrics.replace("\n", "<br>")
     elif br_lyrics == "pack":
-        html_lyrics = re.sub(r"\n+", "<br>", song.lyrics)
+        html_lyrics = re.sub(r"\n+", "<br>", html_lyrics)
     elif br_lyrics == "brless":
-        html_lyrics = song.lyrics.replace("\n", "")
-        
+        html_lyrics = html_lyrics.replace("\n", "")
+    
     # 歌詞の一部をdescriptionに記述
     description_lyrics = song.lyrics.replace("\r\n", "")[:100]
     description += f"歌詞: {description_lyrics}" if description_lyrics else ""


### PR DESCRIPTION
五千兆言絶句(https://lyrics.imicomweb.com/songs/2438) ([編集ログ](https://discord.com/channels/1047741665768648704/1349729106014638080/1375701687515349003))
によって発覚した、歌詞にHTMLを埋め込めるバグを修正します。
このバグを利用してJavaScriptを埋め込むことが可能であるため、クロスサイトスクリプティングを容易に行うことが可能である**重大バグ**です。
> [!WARNING]
> 歌詞表示にHTMLやJavaScriptを用いている曲に**確実に**支障が生じます。