### PR TITLE
[Add] メディアの種類でフィルタリングする検索項目を追加

### DIFF
--- a/subekashi/constants/constants.py
+++ b/subekashi/constants/constants.py
@@ -62,4 +62,18 @@ URL_ICON = {
     r"linkco\.re": "<i class='fas fa-align-justify'></i>",
 }
 
+# サービス名に対応するURL,アイコン,名前
+URLS = {
+    "youtube":([r"youtube\.com",r"youtu\.be"],"<i class='fab fa-youtube'></i>","Youtube"),
+    "soundcloud":([r"soundcloud\.com"],"<i class='fab fa-soundcloud'></i>","SoundCloud"),
+    "twitter":([r"x\.com",r"twitter.com"],"<i class='fab fa-twitter'></i>","Twitter"),
+    "bandcamp":([r"bandcamp.com"],"<i class='fab fa-bandcamp'></i>","BandCamp"),
+    "googledrive":([r"drive\.google\.com"],"<i class='fab fa-google-drive'></i>","Google Drive"),
+    "niconico":([r"nicovideo\.jp"],f"<img src='/static/subekashi/image/niconico.png' alt='ニコニコ動画'></img>","ニコニコ動画"),
+    "bilibili":([r"bilibili\.com"],f"<img src='/static/subekashi/image/bilibili.png' alt='ビリビリ動画'></img>","BiliBili"),
+    "imicomweb":([r"imicomweb\.com"], f"<img src='/static/subekashi/image/imicomweb.png' alt='イミコミュ'></img>","イミコミュ"),
+    "scratch":([r"scratch\.mit\.edu"],"<i class='fas fa-cat'></i>","Scratch"),
+    "linkcore":([r"linkco\.re"],"<i class='fas fa-align-justify'></i>","Linkcore")
+}
+
 SAFE_DOMAINS = list(URL_ICON.keys())

--- a/subekashi/lib/filter.py
+++ b/subekashi/lib/filter.py
@@ -1,4 +1,5 @@
 from django.db.models import Q
+from subekashi.constants.constants import URLS
 
 # topやsearchにあるキーワード検索のフィルター
 def filter_by_keyword(keyword):
@@ -39,31 +40,21 @@ def filter_by_guesser(guesser):
 # メディアの検索に利用するフィルター
 def filter_by_mediatypes(mediatypes):
     
-    mediatypes_arr = mediatypes.split("_")
-    hasother = "other" in mediatypes_arr
-    if hasother:
-        mediatypes_arr.remove("other")
-    SORTREGS={
-        "youtube":r"^http(s)?://(www\.)?youtu(\.)?be",
-        "niconico":r"^http(s)?://(www\.)?nicovideo\.jp",
-        "bilibili":r"^http(s)?://(www\.)?bilibili\.com",
-        "soundcloud":r"^http(s)?://(www\.)?(on\.)?soundcloud\.com",
-        "scratch":r"^http(s)?://(www\.)?scratch\.mit\.edu",
-        "twitter":r"^http(s)?://(www\.)?(twitter|x)\.com",
-        # 未選択時に達成不可能な条件
-        "unselected":r"^_$"
+    mediatypes_arr = mediatypes.split("^")
+    medias = {
+        **URLS,
+        "nourl":(["^$"],"","URL未登録")
     }
-    regexp_all = "|".join(list(map(lambda s: "("+s+")",SORTREGS.values())))
     # mediatypeに当てはまる正規表現を抜き出す
-    regexp = "|".join(list(map(lambda s: "("+SORTREGS[s]+")",mediatypes_arr)))
-    if hasother:
-        return (
-        Q(url__regex = regexp) | 
-        ~Q(url__regex = regexp_all)
-    )
+    media_regex_list = []
+    for m_regexs in mediatypes_arr:
+        for m_regex in medias[m_regexs][0]:
+            media_regex_list.append(f"({m_regex})")
+    media_regex= "|".join(media_regex_list)
     return (
-        Q(url__regex = regexp)
+        Q(url__regex = media_regex)
     )
+
 
 # 未完成フィルター
 filter_by_lack = (

--- a/subekashi/lib/filter.py
+++ b/subekashi/lib/filter.py
@@ -1,5 +1,4 @@
 from django.db.models import Q
-import logging
 
 # topやsearchにあるキーワード検索のフィルター
 def filter_by_keyword(keyword):

--- a/subekashi/lib/filter.py
+++ b/subekashi/lib/filter.py
@@ -1,4 +1,5 @@
 from django.db.models import Q
+import logging
 
 # topやsearchにあるキーワード検索のフィルター
 def filter_by_keyword(keyword):
@@ -34,6 +35,35 @@ def filter_by_guesser(guesser):
     return (
         Q(title__contains = guesser) |
         Q(channel__contains = guesser)
+    )
+
+# メディアの検索に利用するフィルター
+def filter_by_mediatypes(mediatypes):
+    
+    mediatypes_arr = mediatypes.split("_")
+    hasother = "other" in mediatypes_arr
+    if hasother:
+        mediatypes_arr.remove("other")
+    SORTREGS={
+        "youtube":r"^http(s)?://(www\.)?youtu(\.)?be",
+        "niconico":r"^http(s)?://(www\.)?nicovideo\.jp",
+        "bilibili":r"^http(s)?://(www\.)?bilibili\.com",
+        "soundcloud":r"^http(s)?://(www\.)?(on\.)?soundcloud\.com",
+        "scratch":r"^http(s)?://(www\.)?scratch\.mit\.edu",
+        "twitter":r"^http(s)?://(www\.)?(twitter|x)\.com",
+        # 未選択時に達成不可能な条件
+        "unselected":r"^_$"
+    }
+    regexp_all = "|".join(list(map(lambda s: "("+s+")",SORTREGS.values())))
+    # mediatypeに当てはまる正規表現を抜き出す
+    regexp = "|".join(list(map(lambda s: "("+SORTREGS[s]+")",mediatypes_arr)))
+    if hasother:
+        return (
+        Q(url__regex = regexp) | 
+        ~Q(url__regex = regexp_all)
+    )
+    return (
+        Q(url__regex = regexp)
     )
 
 # 未完成フィルター

--- a/subekashi/lib/search.py
+++ b/subekashi/lib/search.py
@@ -10,6 +10,7 @@ MULTI_FILTERS = {
     "imitate": filter_by_imitate,
     "imitated": filter_by_imitated,
     "guesser": filter_by_guesser,
+    "mediatypes": filter_by_mediatypes,
     "islack": filter_by_lack,
 }
 

--- a/subekashi/static/subekashi/css/songs.css
+++ b/subekashi/static/subekashi/css/songs.css
@@ -22,3 +22,12 @@
 #song-cards {
     min-height: 50vh;
 }
+
+#mediatype-div {
+    background-color: #555;
+}
+
+#mediatype-div img {
+    height: 24px;
+    margin-right: 5px;
+}

--- a/subekashi/static/subekashi/js/songs.js
+++ b/subekashi/static/subekashi/js/songs.js
@@ -126,9 +126,9 @@ function formToQuery() {
             /**@type {string} */
             const media = formId.split("-")[1]
             const checked = document.getElementById(formId).checked;
-                query.mediatypes ??= "unselected";
+            query.mediatypes??="";
             if(checked){
-                query.mediatypes += "_"+ media;
+                query.mediatypes += (query.mediatypes.length===0?"":"^")+ media;
             }
             continue;
         }

--- a/subekashi/static/subekashi/js/songs.js
+++ b/subekashi/static/subekashi/js/songs.js
@@ -120,7 +120,17 @@ function formToQuery() {
         if (formId == "songrange") {
             query = { ...query, ...songrangeToQuery(value) };
             continue;
-
+        }
+        if (formId.startsWith("media-"))
+        {
+            /**@type {string} */
+            const media = formId.split("-")[1]
+            const checked = document.getElementById(formId).checked;
+                query.mediatypes ??= "unselected";
+            if(checked){
+                query.mediatypes += "_"+ media;
+            }
+            continue;
         }
         if (formId == "jokerange") {
             query = { ...query, ...isjokeToQuery(value) };

--- a/subekashi/templates/subekashi/songs.html
+++ b/subekashi/templates/subekashi/songs.html
@@ -100,43 +100,7 @@
         </div>
         <label for="mediatype">メディア</label>
         <div id="mediatype-div" style="margin-bottom: 20px;">
-            <div class="checkbox-col">
-                <input type="checkbox" value="media-youtube" id="media-youtube" name="media-youtube" 
-                {% if not 'youtube' in mediatypes %}checked{% endif %}>
-                <label for="media-youtube"><i class="fab fa-youtube"></i>Youtube</label>
-            </div> 
-            <div class="checkbox-col">
-                <input type="checkbox" value="media-niconico" id="media-niconico" name="media-niconico" 
-                {% if not 'niconico' in mediatypes %}checked{% endif %}>
-                <label for="media-niconico"><img src="/static/subekashi/image/niconico.png">ニコニコ動画</label>
-            </div> 
-            <div class="checkbox-col">
-                <input type="checkbox" value="media-bilibili" id="media-bilibili" name="media-bilibili" 
-                {% if not 'bilibili' in mediatypes %}checked{% endif %}>
-                <label for="media-bilibili"><img src="/static/subekashi/image/bilibili.png">bilibili</label>
-            </div> 
-            <div class="checkbox-col">
-                <input type="checkbox" value="media-soundcloud" id="media-soundcloud" name="media-soundcloud" 
-                {% if not 'soundcloud' in mediatypes %}checked{% endif %}>
-                <label for="media-soundcloud"><i class="fab fa-soundcloud"></i>Soundcloud</label>
-            </div> 
-            <div class="checkbox-col">
-                <input type="checkbox" value="media-scratch" id="media-scratch" name="media-scratch" 
-                {% if not 'scratch' in mediatypes %}checked{% endif %}>
-                <label for="media-scratch"><i class="fas fa-cat"></i>Scratch</label>
-            </div> 
-            <div class="checkbox-col">
-                <input type="checkbox" value="media-twitter" id="media-twitter" name="media-twitter" 
-                {% if not 'twitter' in mediatypes %}checked{% endif %}>
-                <label for="media-twitter"><i class="fab fa-twitter"></i>X / Twitter</label>
-            </div> 
-            <div class="checkbox-col">
-                <input type="checkbox" value="media-other" id="media-other" name="media-other" 
-                {% if not 'other' in mediatypes %}checked{% endif %}>
-                <label for="media-other">その他</label>
-            </div> 
-            
-            
+            {{ medias|safe }}
         </div>
         <div class="checkbox-col">
             <input type="checkbox" value="islack" id="islack" {% if islack %}checked{% endif %}>

--- a/subekashi/templates/subekashi/songs.html
+++ b/subekashi/templates/subekashi/songs.html
@@ -98,6 +98,46 @@
                 <option value="random" {% if sort == 'random' %}selected{% endif %}>ランダム</option>
             </select>
         </div>
+        <label for="mediatype">メディア</label>
+        <div id="mediatype-div" style="margin-bottom: 20px;">
+            <div class="checkbox-col">
+                <input type="checkbox" value="media-youtube" id="media-youtube" name="media-youtube" 
+                {% if not 'youtube' in mediatypes %}checked{% endif %}>
+                <label for="media-youtube"><i class="fab fa-youtube"></i>Youtube</label>
+            </div> 
+            <div class="checkbox-col">
+                <input type="checkbox" value="media-niconico" id="media-niconico" name="media-niconico" 
+                {% if not 'niconico' in mediatypes %}checked{% endif %}>
+                <label for="media-niconico"><img src="/static/subekashi/image/niconico.png">ニコニコ動画</label>
+            </div> 
+            <div class="checkbox-col">
+                <input type="checkbox" value="media-bilibili" id="media-bilibili" name="media-bilibili" 
+                {% if not 'bilibili' in mediatypes %}checked{% endif %}>
+                <label for="media-bilibili"><img src="/static/subekashi/image/bilibili.png">bilibili</label>
+            </div> 
+            <div class="checkbox-col">
+                <input type="checkbox" value="media-soundcloud" id="media-soundcloud" name="media-soundcloud" 
+                {% if not 'soundcloud' in mediatypes %}checked{% endif %}>
+                <label for="media-soundcloud"><i class="fab fa-soundcloud"></i>Soundcloud</label>
+            </div> 
+            <div class="checkbox-col">
+                <input type="checkbox" value="media-scratch" id="media-scratch" name="media-scratch" 
+                {% if not 'scratch' in mediatypes %}checked{% endif %}>
+                <label for="media-scratch"><i class="fas fa-cat"></i>Scratch</label>
+            </div> 
+            <div class="checkbox-col">
+                <input type="checkbox" value="media-twitter" id="media-twitter" name="media-twitter" 
+                {% if not 'twitter' in mediatypes %}checked{% endif %}>
+                <label for="media-twitter"><i class="fab fa-twitter"></i>X / Twitter</label>
+            </div> 
+            <div class="checkbox-col">
+                <input type="checkbox" value="media-other" id="media-other" name="media-other" 
+                {% if not 'other' in mediatypes %}checked{% endif %}>
+                <label for="media-other">その他</label>
+            </div> 
+            
+            
+        </div>
         <div class="checkbox-col">
             <input type="checkbox" value="islack" id="islack" {% if islack %}checked{% endif %}>
             <label for="islack">作成途中</label>

--- a/subekashi/views/songs.py
+++ b/subekashi/views/songs.py
@@ -1,4 +1,6 @@
 from django.shortcuts import render
+from subekashi.constants.constants import   URLS
+
 
 QUERY_OR_COOKIE_FORMS = [
     ("isdetail", "isdetail", "False"),
@@ -21,5 +23,17 @@ def songs(request) :
     
     for filter in FILER_FORMS:
         dataD[filter] = bool(GET.get(filter))
+    
+    # メディアリスト
+    media_checks = []
+    # URLSに未登録時の挙動を追加する
+    medias = {
+        **URLS,
+        "nourl":(["^$"],"","URL未登録")
+    }
+    for name,tuple in medias.items():
+        url,icon,display_name = tuple
+        media_checks.append(f"""<div class="checkbox-col"><input type="checkbox" value="media-{name}" id="media-{name}" name="media-{name}" checked><label for="media-{name}">{icon}{display_name}</label></div>""")
+    dataD["medias"] = "\n".join(media_checks)
 
     return render(request, "subekashi/songs.html", dataD)


### PR DESCRIPTION
検索画面にメディアの種類を複数選択できるチェックボックスを追加します。
現在のコードではデフォルトで全て選択されています。
選択したメディア名はアンダーバー区切りでクエリに追加されます。
デフォルトでunselectedが設定されており、どれも選択しなかった場合は0件になります。
（どれも選択しなかった場合に0件になる仕様は合理的ですが、利用側として使用するタイミングがないため代理の仕様を考えても良いかもしれません。）

バックエンド側では、選択したメディアに応じたURLの正規表現をOR条件で抽出します。
「その他」は、設定されている全てのURL正規表現に当てはまらないURLである曲を抽出します。
unselectedは、URLが「_」である曲に当てはまるよう（つまり普通は当てはまらない）明示的に指示しています。

課題
- メディアリストを動的に追加する。
  - メディア名、Id、URL、アイコンのHTMLタグを特定ファイルに書き込み、HTMLのテンプレートや処理に適用させる。

（Pythonがそんなに得意ではないため、適切でないコードを書いてしまっているかもしれません）