### PR TITLE
[FIX] discord編集履歴で元の値がない項目の表示がおかしくなるバグの修正

### DIFF
--- a/subekashi/views/song_edit.py
+++ b/subekashi/views/song_edit.py
@@ -178,14 +178,18 @@ def song_edit(request, song_id):
 
                 # 共通：Markdownテーブル
                 changes += f"| {label} | {before_br} | {after_br} |\n"
-
+                
                 # Discord用テキスト
+                discord_text += f"**{label}**："
                 if label == "歌詞":
-                    discord_text += f"**{label}**：```{after}```\n"
+                    discord_text += f"```{after}```\n"
                 elif label == "模倣":
-                    discord_text += f"**{label}**：\n{before} \n:arrow_down: \n{after}\n"
+                    discord_text += f"\n{before} \n:arrow_down: \n{after}\n"
                 else:
-                    discord_text += f"**{label}**：`{before}` :arrow_right: `{after}`\n"
+                    # beforeが存在する場合追記する
+                    if len(before) != 0:
+                        discord_text += f"`{before}` :arrow_right: "
+                    discord_text += f"`{after}`\n"
                 
         title = f"{title}の{'と'.join(changed_labels)}を編集"
         


### PR DESCRIPTION
https://github.com/izumin2000/subekashi/issues/509 の修正
(Assignees無視してやってしまってすいません)