### PR TITLE
fix: Update unregistered URL and lyrics links to use song edit page

### DIFF
--- a/subekashi/templatetags/song_card.py
+++ b/subekashi/templatetags/song_card.py
@@ -49,8 +49,8 @@ def get_url(song):
     
     # 未登録なら
     elif not urls:
-        new_url = reverse('subekashi:song_new')
-        return mark_safe(f'<object><a href="{new_url}?id={song.id}">URL未登録</a></object>')
+        edit_url = reverse('subekashi:song_edit', args=[song.id])
+        return mark_safe(f'<object><a href="{edit_url}">URL未登録</a></object>')
     
     # URLを登録しているのなら
     for url in urls:
@@ -71,8 +71,8 @@ def get_lyrics(song):
     
     # 歌詞を登録していないのなら
     if not lyrics and not song.isinst:
-        new_url = reverse('subekashi:song_new')
-        return mark_safe(f'<object><a href="{new_url}?id={song.id}"><i class="fas fa-align-center"></i>歌詞未登録</a></object>')
+        edit_url = reverse('subekashi:song_edit', args=[song.id])
+        return mark_safe(f'<object><a href="{edit_url}"><i class="fas fa-align-center"></i>歌詞未登録</a></object>')
     
     # 歌詞を登録しているのなら
     return mark_safe(f'<i class="fas fa-align-center"></i>{lyrics}')


### PR DESCRIPTION
Change links from /songs/new/?id={song.id} to /songs/{song.id}/edit/ for both URL未登録 and 歌詞未登録 cases in song_card.py