### PR TITLE
fix: Add 'id' field to allowed sort options in SongFilter

### DIFF
--- a/subekashi/lib/filters.py
+++ b/subekashi/lib/filters.py
@@ -124,6 +124,7 @@ class SongFilter(django_filters.FilterSet):
     # ソート
     sort = django_filters.OrderingFilter(
         fields=(
+            ('id', 'id'),
             ('title', 'title'),
             ('channel', 'channel'),
             ('upload_time', 'upload_time'),


### PR DESCRIPTION
## Summary

Fixed the validation error that occurred when users tried to sort songs by registration date (id).

## Changes
- Added `('id', 'id')` to the OrderingFilter fields in `subekashi/lib/filters.py`
- This allows sorting by `id` and `-id` as shown in the template

Fixes #629

---

Generated with [Claude Code](https://claude.ai/code)