### PR TITLE
Prevent scroll wheel from changing number input values

### DIFF
--- a/subekashi/static/subekashi/js/base.js
+++ b/subekashi/static/subekashi/js/base.js
@@ -15,6 +15,13 @@ document.querySelectorAll('textarea').forEach((textarea) => {
     };
 });
 
+// <input type="number">上でスクロールしても値が変わらないようにする
+document.addEventListener('wheel', function(event) {
+    if (event.target.type === 'number') {
+        event.preventDefault();
+    }
+}, { passive: false });
+
 // DRFのAPIの取得
 async function getJson(path) {
     const res = await fetch(`${baseURL()}/api/${path}`, { cache: "reload" });


### PR DESCRIPTION
Added event listener to prevent default wheel behavior on number input fields.

Fixes #635

Generated with [Claude Code](https://claude.ai/code)