### PR TITLE
Fix scroll issue on number input fields in search screen

### DIFF
--- a/subekashi/static/subekashi/js/base.js
+++ b/subekashi/static/subekashi/js/base.js
@@ -18,9 +18,9 @@ document.querySelectorAll('textarea').forEach((textarea) => {
 // <input type="number">上でスクロールしても値が変わらないようにする
 document.addEventListener('wheel', function(event) {
     if (event.target.type === 'number') {
-        event.preventDefault();
+        event.target.blur();
     }
-}, { passive: false });
+}, { passive: true });
 
 // DRFのAPIの取得
 async function getJson(path) {


### PR DESCRIPTION
## Summary

Fixed the issue where users couldn't scroll the page when hovering over `type="number"` input fields on the search screen.

## Changes

- Modified the wheel event handler in `subekashi/static/subekashi/js/base.js`
- Changed from `event.preventDefault()` to `event.target.blur()`
- Changed event listener to passive mode for better performance

This allows page scrolling while preventing number values from changing when scrolling over number inputs.

Fixes #656

Generated with [Claude Code](https://claude.ai/code)