### PR TITLE
[Author DB] [Phase 3-2] Views・フィルターをauthorsフィールド対応に更新（修正版）

### DIFF
--- a/subekashi/lib/filter.py
+++ b/subekashi/lib/filter.py
@@ -5,7 +5,7 @@ from subekashi.constants.constants import ALL_MEDIAS
 def filter_by_keyword(keyword):
     return (
         Q(title__contains = keyword) |
-        Q(channel__contains = keyword) |
+        Q(authors__name__contains = keyword) |
         Q(lyrics__contains = keyword) |
         Q(url__contains = keyword)
     )
@@ -34,7 +34,7 @@ def filter_by_imitated(imitated):
 def filter_by_guesser(guesser):
     return (
         Q(title__contains = guesser) |
-        Q(channel__contains = guesser)
+        Q(authors__name__contains = guesser)
     )
 
 # メディアの検索に利用するフィルター
@@ -54,20 +54,21 @@ def filter_by_mediatypes(mediatypes):
 # 未完成フィルター
 filter_by_lack = (
     (Q(isdeleted = False) & Q(url = "")) |
-    (Q(isoriginal = False) & Q(issubeana = True) & Q(imitate = "") & ~Q(channel = "全てあなたの所為です。")) | 
+    (Q(isoriginal = False) & Q(issubeana = True) & Q(imitate = "") & ~Q(authors__id=1)) |
     (Q(isinst = False) & Q(lyrics = ""))
 )
 
+# TODO filter_by_lackに共通化
 # 未完成かどうか
 def is_lack(song):
     if (song.isdeleted == False) and (song.url == ""):
         return True
-    
-    if (song.isoriginal == False) and (song.issubeana == False) and (song.imitate == "") and (song.channel == "全てあなたの所為です。"):
+
+    if (song.isoriginal == False) and (song.issubeana == False) and (song.imitate == "") and not song.authors.filter(id=1).exists():
         return True
-    
+
     if (song.isinst == False) and (song.lyrics == ""):
         return True
-    
+
     return False   
         

--- a/subekashi/lib/filters.py
+++ b/subekashi/lib/filters.py
@@ -43,8 +43,10 @@ class SongFilter(django_filters.FilterSet):
         validators=[validate_max_length(500)]
     )
     channel = django_filters.CharFilter(
+        field_name='authors__name',
         lookup_expr='icontains',
-        validators=[validate_max_length(500)]
+        validators=[validate_max_length(500)],
+        distinct=True
     )
     lyrics = django_filters.CharFilter(
         lookup_expr='icontains',
@@ -62,9 +64,10 @@ class SongFilter(django_filters.FilterSet):
         validators=[validate_max_length(500)]
     )
     channel_exact = django_filters.CharFilter(
-        field_name='channel',
+        field_name='authors__name',
         lookup_expr='exact',
-        validators=[validate_max_length(500)]
+        validators=[validate_max_length(500)],
+        distinct=True
     )
 
     # YouTubeデータのgte/lteフィルタ
@@ -179,11 +182,18 @@ class SongFilter(django_filters.FilterSet):
             'id', '-id',
             'title', '-title',
             'channel', '-channel',
+            'authors__name', '-authors__name',
             'upload_time', '-upload_time',
             'view', '-view',
             'like', '-like',
             'post_time', '-post_time',
         }
+
+        # channelソートをauthors__nameに変換（後方互換性のため）
+        if value == 'channel':
+            value = 'authors__name'
+        elif value == '-channel':
+            value = '-authors__name'
 
         # バリデーション
         if value not in allowed_fields:

--- a/subekashi/models.py
+++ b/subekashi/models.py
@@ -54,7 +54,12 @@ class Song(models.Model):
 
     def __str__(self):
         return self.title
-    
+
+    def authors_str(self, separator=", "):
+        """作者名をカンマ区切りの文字列で返す。authorsが空の場合はchannelフィールドを返す"""
+        author_names = [author.name for author in self.authors.all()]
+        return separator.join(author_names) if author_names else self.channel
+
     def save(self, *args, **kwargs):
         if self.lyrics:
             self.lyrics = self.lyrics.replace("\r\n", "\n")

--- a/subekashi/views/channel.py
+++ b/subekashi/views/channel.py
@@ -7,10 +7,10 @@ def channel(request, channelName) :
         "metatitle" : channelName,
     }
     dataD["channel"] = channelName
-    songInsL = []
-    for songIns in Song.objects.all() :
-        if channelName in songIns.channel.split(",") :
-            songInsL.append(songIns)
+
+    # authorsフィールドでフィルタ
+    songInsL = Song.objects.filter(authors__name=channelName).distinct()
+
     dataD["songInsL"] = songInsL
     titles = ", ".join([songIns.title for songIns in songInsL[::-1]])
     if len(titles) >= 80:

--- a/subekashi/views/song.py
+++ b/subekashi/views/song.py
@@ -56,17 +56,17 @@ def song(request, song_id):
     
     # タグを持っているかどうかの確認
     has_tag = False
-    has_tag |= song.channel == "全てあなたの所為です。"
+    has_tag |= song.authors.filter(id=1).exists()
     has_tag |= is_lack(song) or song.isdraft or song.isoriginal or song.isjoke or song.isinst
     has_tag |= not(song.issubeana) or song.isdeleted
     
     # テンプレートに渡す辞書を作成
     dataD = {
         "description": description,
-        "metatitle": f"{song.title} / {song.channel}",
+        "metatitle": f"{song.title} / {song.authors_str()}",
         "song": song,
         "br_cleaned_lyrics": br_cleaned_lyrics,
-        "channels": song.channel.split(","),
+        "channels": [author.name for author in song.authors.all()] or song.channel.split(","),
         "is_lack": is_lack(song),
         "links": links,
         "imitate_list": imitate_list,

--- a/subekashi/views/song_delete.py
+++ b/subekashi/views/song_delete.py
@@ -49,7 +49,7 @@ def song_delete(request, song_id):
         ```{song.id}``` \n\
         {ROOT_URL}/songs/{song.id} \n\
         タイトル：{song.title}\n\
-        チャンネル名：{song.channel}\n\
+        チャンネル名：{song.authors_str()}\n\
         理由：{reason}\n\
         編集者：{editor}\
         '

--- a/subekashi/views/song_edit.py
+++ b/subekashi/views/song_edit.py
@@ -136,16 +136,11 @@ def song_edit(request, song_id):
                 info += f"{song.title}\n"
             return info[:-1]        # 最後の改行は不要
 
-        # authorsを改行区切りの文字列に変換
-        def authors2Info(authors):
-            author_names = [author.name for author in authors.all()]
-            return ", ".join(author_names) if author_names else ""
-
         # songを更新する前にhistoryのために更新前後のsongの情報を記録しておく
         COLUMNS = [
             {"label": "タイトル", "before": song.title ,"after": title},
             {"label": "チャンネル名", "before": song.channel ,"after": cleaned_channel},
-            {"label": "作者", "before": authors2Info(song.authors), "after": "\n".join([a.name for a in author_objects])},
+            {"label": "作者", "before": song.authors_str(), "after": ", ".join([a.name for a in author_objects])},
             {"label": "URL", "before": song.url ,"after": cleaned_url},
             {"label": "オリジナル", "before": yes_no(song.isoriginal) ,"after": yes_no(is_original)},
             {"label": "削除済み", "before": yes_no(song.isdeleted) ,"after": yes_no(is_deleted)},


### PR DESCRIPTION
- models.py: Song.authors_str()メソッド追加
- song.py: authors_str()使用、author.id==1でタグ判定
- song_delete.py: authors_str()使用
- song_edit.py: authors_str()使用
- channel.py: authors__nameでフィルタリング
- lib/filters.py: channelフィルターをauthors__nameに変更、ソート対応、distinct=True追加
- lib/filter.py: filter_by_keyword/guesserをauthors__name__containsに更新、author.id==1で判定

🤖 Generated with [Claude Code](https://claude.com/claude-code)