### PR TITLE
Add validation for empty/whitespace author fields

### DIFF
--- a/subekashi/static/subekashi/js/song_edit.js
+++ b/subekashi/static/subekashi/js/song_edit.js
@@ -143,9 +143,15 @@ async function checkTitleChannelForm() {
     const loadingEle = `<img src="${baseURL()}/static/subekashi/image/loading.gif" id="loading" alt='loading'></img>`
     songEditInfoTitleChannelEle.innerHTML = loadingEle;
 
-    // タイトルとチャンネル名が空の場合
-    if (titleEle.value === '' || channelEle.value === '') {
-        songEditInfoTitleChannelEle.innerHTML = "<span class='error'><i class='fas fa-ban error'></i>タイトルとチャンネル名を入力してください</span>";
+    // 作者が空白の場合
+    if (channelEle.value === '' || channelEle.value.trim() === '') {
+        songEditInfoTitleChannelEle.innerHTML = "<span class='error'><i class='fas fa-ban error'></i>作者は空白にできません</span>";
+        return;
+    }
+
+    // タイトルが空白の場合
+    if (titleEle.value === '' || titleEle.value.trim() === '') {
+        songEditInfoTitleChannelEle.innerHTML = "<span class='error'><i class='fas fa-ban error'></i>タイトルは空白にできません</span>";
         return;
     }
 
@@ -292,6 +298,15 @@ urlEle.addEventListener('input', checkUrlForm);
 function checkButton() {
     // ボタンのdisabledの変更
     const songEditSubmitEle = document.getElementById('song-edit-submit');
+    const songEditInfoSubmitEle = document.getElementById('song-edit-info-submit');
+
+    // 作者が空白の場合は登録ボタンを無効化
+    if (channelEle.value === '' || channelEle.value.trim() === '') {
+        songEditSubmitEle.disabled = true;
+        songEditInfoSubmitEle.innerHTML = "<span class='error'><i class='fas fa-ban error'></i>作者は空白にできません</span>";
+        return;
+    }
+
     songEditSubmitEle.disabled = !(isTitleChannelValid && isUrlValid)
 
     // 未完成に関する変数の定義

--- a/subekashi/static/subekashi/js/song_new.js
+++ b/subekashi/static/subekashi/js/song_new.js
@@ -93,9 +93,16 @@ async function checkManualForm() {
     const loadingEle = `<img src="${baseURL()}/static/subekashi/image/loading.gif" id="loading" alt='loading'></img>`
     newFormAutoManualEle.innerHTML = loadingEle;
 
-    // どちらかが空の場合
-    if (channelEle.value === '' || titleEle.value === '') {
-        newFormAutoManualEle.innerHTML = "";
+    // 作者が空白の場合
+    if (channelEle.value === '' || channelEle.value.trim() === '') {
+        newFormAutoManualEle.innerHTML = "<span class='error'><i class='fas fa-ban error'></i>作者は空白にできません</span>";
+        document.getElementById('new-submit-manual').disabled = true;
+        return;
+    }
+
+    // タイトルが空の場合
+    if (titleEle.value === '' || titleEle.value.trim() === '') {
+        newFormAutoManualEle.innerHTML = "<span class='error'><i class='fas fa-ban error'></i>タイトルは空白にできません</span>";
         document.getElementById('new-submit-manual').disabled = true;
         return;
     }

--- a/subekashi/views/song_edit.py
+++ b/subekashi/views/song_edit.py
@@ -63,6 +63,11 @@ def song_edit(request, song_id):
         if ("" in [title, channel]) :
             dataD["error"] = "タイトルかチャンネルが空です。"
             return render(request, 'subekashi/song_edit.html', dataD)
+
+        # チャンネル(作者)が空白のみの場合はエラー
+        if title.strip() == "" or channel.strip() == "":
+            dataD["error"] = "作者は空白にできません。"
+            return render(request, 'subekashi/song_edit.html', dataD)
         
         # DBに保存する値たち
         # TODO Channelテーブルを利用する

--- a/subekashi/views/song_new.py
+++ b/subekashi/views/song_new.py
@@ -53,6 +53,11 @@ def song_new(request):
         if ("" in [title, channel]) :
             dataD["error"] = "タイトルかチャンネルが空です。"
             return render(request, 'subekashi/song_new.html', dataD)
+
+        # チャンネル(作者)が空白のみの場合はエラー
+        if title.strip() == "" or channel.strip() == "":
+            dataD["error"] = "作者は空白にできません。"
+            return render(request, 'subekashi/song_new.html', dataD)
         
         # DBに保存する値たち
         # TODO Channelテーブルを利用する


### PR DESCRIPTION
## Summary
Implemented validation for empty/whitespace-only author (channel) fields in both frontend and backend.

## Changes
- Frontend: Validate channel field in song_new.js and song_edit.js
- Show error message "作者は空白にできません" when channel is empty/whitespace
- Disable submit buttons when validation fails
- Backend: Add strip() validation in song_new.py and song_edit.py

Fixes #705

---
Generated with [Claude Code](https://claude.ai/code)