### PR TITLE
[Author DB] [Phase 10] authorの空白バリデーション実装

### DIFF
--- a/subekashi/static/subekashi/js/song_edit.js
+++ b/subekashi/static/subekashi/js/song_edit.js
@@ -134,6 +134,9 @@ async function songGuesserClick(id) {
 // タイトルと作者の入力チェック
 const titleEle = document.getElementById('title');
 const authorsEle = document.getElementById('authors');
+var isTitleAuthorFormTouched = false;  // ユーザーが入力したかどうかのフラグ
+authorsEle.addEventListener('input', () => { isTitleAuthorFormTouched = true; checkTitleAuthorForm(); });
+titleEle.addEventListener('input', () => { isTitleAuthorFormTouched = true; checkTitleAuthorForm(); });
 var isTitleAuthorValid = false;
 async function checkTitleAuthorForm() {
     isTitleAuthorValid = false;
@@ -143,9 +146,23 @@ async function checkTitleAuthorForm() {
     const loadingEle = `<img src="${baseURL()}/static/subekashi/image/loading.gif" id="loading" alt='loading'></img>`
     songEditInfoTitleAuthorsEle.innerHTML = loadingEle;
 
-    // タイトルと作者が空の場合
-    if (titleEle.value === '' || authorsEle.value === '') {
-        songEditInfoTitleAuthorsEle.innerHTML = "<span class='error'><i class='fas fa-ban error'></i>タイトルと作者を入力してください</span>";
+    // 作者が空の場合（ユーザーが入力した後のみエラー表示）
+    if (authorsEle.value.trim() === '') {
+        if (isTitleAuthorFormTouched) {
+            songEditInfoTitleAuthorsEle.innerHTML = "<span class='error'><i class='fas fa-ban error'></i>作者は空白にできません</span>";
+        } else {
+            songEditInfoTitleAuthorsEle.innerHTML = "";
+        }
+        return;
+    }
+
+    // タイトルが空の場合
+    if (titleEle.value === '') {
+        if (isTitleAuthorFormTouched) {
+            songEditInfoTitleAuthorsEle.innerHTML = "<span class='error'><i class='fas fa-ban error'></i>タイトルを入力してください</span>";
+        } else {
+            songEditInfoTitleAuthorsEle.innerHTML = "";
+        }
         return;
     }
 

--- a/subekashi/static/subekashi/js/song_new.js
+++ b/subekashi/static/subekashi/js/song_new.js
@@ -86,6 +86,9 @@ urlEle.addEventListener('input', checkAutoForm)
 // タイトル・作者入力フォームの入力チェック
 var authorsEle = document.getElementById('authors');
 var titleEle = document.getElementById('title');
+var isManualFormTouched = false;  // ユーザーが入力したかどうかのフラグ
+authorsEle.addEventListener('input', () => { isManualFormTouched = true; checkManualForm(); });
+titleEle.addEventListener('input', () => { isManualFormTouched = true; checkManualForm(); });
 async function checkManualForm() {
     const authorsEle = document.getElementById('authors');
     const titleEle = document.getElementById('title');
@@ -94,8 +97,19 @@ async function checkManualForm() {
     const loadingEle = `<img src="${baseURL()}/static/subekashi/image/loading.gif" id="loading" alt='loading'></img>`
     newFormAutoManualEle.innerHTML = loadingEle;
 
-    // どちらかが空の場合
-    if (authorsEle.value === '' || titleEle.value === '') {
+    // 作者が空の場合（ユーザーが入力した後のみエラー表示）
+    if (authorsEle.value.trim() === '') {
+        if (isManualFormTouched) {
+            newFormAutoManualEle.innerHTML = "<span class='error'><i class='fas fa-ban error'></i>作者は空白にできません</span>";
+        } else {
+            newFormAutoManualEle.innerHTML = "";
+        }
+        document.getElementById('new-submit-manual').disabled = true;
+        return;
+    }
+
+    // タイトルが空の場合
+    if (titleEle.value === '') {
         newFormAutoManualEle.innerHTML = "";
         document.getElementById('new-submit-manual').disabled = true;
         return;

--- a/subekashi/views/song_edit.py
+++ b/subekashi/views/song_edit.py
@@ -60,9 +60,14 @@ def song_edit(request, song_id):
                 該当のURLを登録できるように、ご連絡ください。"
                 return render(request, 'subekashi/song_edit.html', dataD)
 
-        # タイトルと作者が空の場合はエラー
-        if ("" in [title, authors_input]) :
-            dataD["error"] = "タイトルか作者が空です。"
+        # 作者が空または空白のみの場合はエラー
+        if not authors_input.strip():
+            dataD["error"] = "作者は空白にできません。"
+            return render(request, 'subekashi/song_edit.html', dataD)
+
+        # タイトルが空の場合はエラー
+        if not title:
+            dataD["error"] = "タイトルが未入力です。"
             return render(request, 'subekashi/song_edit.html', dataD)
 
         # DBに保存する値たち

--- a/subekashi/views/song_new.py
+++ b/subekashi/views/song_new.py
@@ -50,9 +50,14 @@ def song_new(request):
             dataD["error"] = "URLは既に登録されています。"
             return render(request, 'subekashi/song_new.html', dataD)
         
-        # タイトルか作者が空の場合はエラー
-        if ("" in [title, authors_input]) :
-            dataD["error"] = "タイトルか作者が空です。"
+        # 作者が空または空白のみの場合はエラー
+        if not authors_input.strip():
+            dataD["error"] = "作者は空白にできません。"
+            return render(request, 'subekashi/song_new.html', dataD)
+
+        # タイトルが空の場合はエラー
+        if not title:
+            dataD["error"] = "タイトルが未入力です。"
             return render(request, 'subekashi/song_new.html', dataD)
 
         cleaned_authors = authors_input.replace(" ,", ",").replace(", ", ",")


### PR DESCRIPTION
## 目的
作者入力欄が空白の場合のバリデーションを実装し、ユーザーに適切なエラーメッセージを表示する

## 実施内容

### フロントエンドのバリデーション

#### song_new.js
- `isManualFormTouched`フラグを追加（ユーザーが入力したかどうかを追跡）
- `authorsEle`と`titleEle`に`input`イベントリスナーを追加
- **ユーザーが入力した後のみ**「作者は空白にできません」を表示
- `#new-submit-manual`をdisable

#### song_edit.js
- `isTitleAuthorFormTouched`フラグを追加
- `authorsEle`と`titleEle`に`input`イベントリスナーを追加
- **ユーザーが入力した後のみ**「作者は空白にできません」を表示
- ボタンをdisable

### バックエンドのバリデーション

#### song_new.py & song_edit.py
- `not authors_input.strip()`で空白のみの入力をチェック
- エラーメッセージ「作者は空白にできません。」を返す

## 動作
- ✅ ページアクセス直後にはエラーメッセージを表示しない
- ✅ ユーザーが入力フィールドに触れた後のみバリデーションを実行
- ✅ リアルタイムでバリデーション
- ✅ 空白のみの入力もエラーとして検出
- ✅ フロントエンドとバックエンドの両方でバリデーション

## 変更ファイル
- [subekashi/static/subekashi/js/song_new.js](subekashi/static/subekashi/js/song_new.js)
- [subekashi/static/subekashi/js/song_edit.js](subekashi/static/subekashi/js/song_edit.js)
- [subekashi/views/song_new.py](subekashi/views/song_new.py)
- [subekashi/views/song_edit.py](subekashi/views/song_edit.py)

Closes #705

🤖 Generated with [Claude Code](https://claude.com/claude-code)