### PR TITLE
[SongLink DB] Phase 2: Song.urlからSongLinkへのデータ移行コマンド

### DIFF
--- a/subekashi/management/commands/migrate_song_links.py
+++ b/subekashi/management/commands/migrate_song_links.py
@@ -1,0 +1,97 @@
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from subekashi.models import Song, SongLink
+
+SAMPLE_SIZE = 10
+
+
+class Command(BaseCommand):
+    help = 'Song.urlからSongLinkへのデータ移行を行う'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='実際には変更を加えず、何が起こるかだけを表示する',
+        )
+        parser.add_argument(
+            '--song-id',
+            type=int,
+            default=None,
+            help='特定のSong IDのみ処理する',
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options['dry_run']
+        song_id = options['song_id']
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING('=== DRY RUN MODE ==='))
+            self.stdout.write(self.style.WARNING('実際の変更は行われません\n'))
+
+        songs = Song.objects.exclude(url='').exclude(url__isnull=True)
+        if song_id:
+            songs = songs.filter(id=song_id)
+
+        self.stdout.write(f'処理対象曲数: {songs.count()}')
+
+        if dry_run:
+            self._dry_run(songs)
+        else:
+            self._migrate(songs)
+
+    def _dry_run(self, songs):
+        already_migrated = 0
+        total_urls = 0
+
+        for song in songs:
+            if SongLink.objects.filter(song=song).exists():
+                already_migrated += 1
+                continue
+            urls = [u.strip() for u in song.url.split(',') if u.strip()]
+            total_urls += len(urls)
+
+        self.stdout.write(f'移行済み（スキップ予定）: {already_migrated}曲')
+        self.stdout.write(f'作成予定SongLink数: {total_urls}件')
+
+        sample = []
+        for song in songs:
+            if not SongLink.objects.filter(song=song).exists():
+                sample.append(song)
+            if len(sample) >= SAMPLE_SIZE:
+                break
+
+        if sample:
+            self.stdout.write(f'\nサンプル（最大{SAMPLE_SIZE}件）:')
+            for song in sample:
+                urls = [u.strip() for u in song.url.split(',') if u.strip()]
+                self.stdout.write(f'  Song ID {song.id}: {len(urls)}件のURL')
+                for url in urls:
+                    self.stdout.write(f'    - {url}')
+
+    def _migrate(self, songs):
+        total_created = 0
+        total_skipped = 0
+
+        with transaction.atomic():
+            for song in songs:
+                if SongLink.objects.filter(song=song).exists():
+                    total_skipped += 1
+                    continue
+
+                urls = [u.strip() for u in song.url.split(',') if u.strip()]
+                if not urls:
+                    total_skipped += 1
+                    continue
+
+                for url in urls:
+                    SongLink.objects.create(song=song, url=url)
+                total_created += len(urls)
+
+                processed = total_created + total_skipped
+                if processed % 100 == 0:
+                    self.stdout.write(f'処理済み: {processed}件...')
+
+        self.stdout.write(self.style.SUCCESS('\n[OK] 処理完了'))
+        self.stdout.write(f'作成したSongLink数: {total_created}')
+        self.stdout.write(f'スキップした曲数: {total_skipped}')


### PR DESCRIPTION
## 概要
Issue #751 の対応。`Song.url`（コンマ区切り文字列）から `SongLink` レコードを生成するカスタム管理コマンドを追加。

## 変更内容
- `subekashi/management/commands/migrate_song_links.py` を追加

## 使い方
```
# 実行前に件数確認（サンプル10件表示）
python manage.py migrate_song_links --dry-run

# 全件移行
python manage.py migrate_song_links

# 特定Songのみ
python manage.py migrate_song_links --song-id 123
```

## 仕様
- 既に `SongLink` が存在するSongはスキップ（二重作成防止）
- `transaction.atomic()` で全件一括コミット（途中失敗時はロールバック）
- `--dry-run` 時はサンプル最大10件のURL一覧と作成予定件数を表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)