### PR TITLE
[SongLink DB] Phase 4: バックエンドのSong.url参照をSongLinkに移行

### DIFF
--- a/subekashi/lib/query_filters.py
+++ b/subekashi/lib/query_filters.py
@@ -1,6 +1,7 @@
-from django.db.models import Q
+from django.db.models import Q, Exists, OuterRef
 from subekashi.constants.constants import ALL_MEDIAS
 from subekashi.lib.url import clean_url
+from subekashi.models import SongLink
 
 # topやsearchにあるキーワード検索のフィルター
 def filter_by_keyword(keyword):
@@ -9,10 +10,10 @@ def filter_by_keyword(keyword):
         Q(authors__name__contains = keyword) |
         Q(lyrics__contains = keyword)
     )
-    # URLっぽいキーワード（://を含む）の場合のみURLフィールドも検索
+    # URLっぽいキーワード（://を含む）の場合のみSongLinkも検索
     url_keyword = clean_url(keyword)
     if '://' in url_keyword:
-        q |= Q(url__contains = url_keyword)
+        q |= Q(links__url__icontains=url_keyword)
     return q
 
 # 模倣元のフィルター
@@ -53,12 +54,14 @@ def filter_by_mediatypes(mediatypes):
                 continue
     media_regex = "|".join(media_regex_list)
     return (
-        Q(url__regex = media_regex)
+        Q(links__url__regex=media_regex)
     )
 
 # 未完成フィルター
-filter_by_lack = (
-    Q(isdeleted=False, url="") |
-    Q(isoriginal=False, issubeana=True, imitate="") & ~Q(authors__id=1) |
-    Q(isinst=False, lyrics="")
-)
+def filter_by_lack():
+    any_links = SongLink.objects.filter(song=OuterRef('pk'))
+    return (
+        Q(isdeleted=False) & ~Exists(any_links) |
+        Q(isoriginal=False, issubeana=True, imitate="") & ~Q(authors__id=1) |
+        Q(isinst=False, lyrics="")
+    )

--- a/subekashi/lib/song_filterset.py
+++ b/subekashi/lib/song_filterset.py
@@ -164,7 +164,7 @@ class SongFilter(django_filters.FilterSet):
     def filter_islack(self, queryset, name, value):
         """不完全な曲をフィルタ"""
         if value:
-            return queryset.filter(filter_by_lack)
+            return queryset.filter(filter_by_lack())
         return queryset
 
     def filter_sort(self, queryset, name, value):
@@ -230,7 +230,7 @@ class SongFilter(django_filters.FilterSet):
             queryset = queryset.filter(like__gte=1)
 
         # フィルタ使用時、またはrandom/authorソート時にdistinct()を適用
-        NEED_DISTINCT_KEY_LIST = ['author', 'author_exact', 'keyword', 'guesser', 'islack', 'url']
+        NEED_DISTINCT_KEY_LIST = ['author', 'author_exact', 'keyword', 'guesser', 'islack', 'url', 'mediatypes']
         NEED_DISTINCT_SORT_LIST = ['random', 'author', '-author']
         if any(key in self.data for key in NEED_DISTINCT_KEY_LIST) or (self.data.get('sort') in NEED_DISTINCT_SORT_LIST):
             ids = queryset.values('id').distinct()

--- a/subekashi/management/commands/youtube.py
+++ b/subekashi/management/commands/youtube.py
@@ -8,9 +8,9 @@ from time import sleep
 class Command(BaseCommand):
     help = "YouTube API関連。idオプションを加えることでそのidのみのsongレコードを更新する"
     
-    # song.urlから(複数の)YouTube動画IDを取得しリストにする
+    # SongLinkからYouTube動画IDを取得しリストにする
     def get_youtube_ids(self, song):
-        urls = song.url.split(",")
+        urls = song.links.values_list('url', flat=True)
         video_ids = [get_youtube_id(url) for url in urls if is_youtube_url(url)]
         return video_ids
     
@@ -24,8 +24,8 @@ class Command(BaseCommand):
             "view": 0,
             "like": 0
         }
-        
-        # song.urlに1つもYouTubeの動画が無かったら
+
+        # SongLinkに1つもYouTubeの動画が無かったら
         if not video_ids :
             return {}
 
@@ -73,9 +73,9 @@ class Command(BaseCommand):
             
             self.save_song(song, info)
             return
-        
-        # 全てのsongが対象なら
-        for song in Song.objects.exclude(url = ""):
+
+        # 全てのsongが対象なら（SongLinkが存在するSongのみ）
+        for song in Song.objects.filter(links__isnull=False).distinct():
             info = self.get_youtube_info_sum(song)
             if not info:
                 continue

--- a/subekashi/templatetags/song_card.py
+++ b/subekashi/templatetags/song_card.py
@@ -47,7 +47,7 @@ def get_view(song):
 
 @register.simple_tag
 def get_url(song):
-    urls = song.url.split(',') if song.url else ""
+    active_links = song.links.all()
     i_tags = ""
     
     # 非公開なら
@@ -55,14 +55,14 @@ def get_url(song):
         i_tags += "<i class='far fa-eye-slash'></i>"
     
     # 未登録なら
-    elif not urls:
+    elif not active_links.exists():
         edit_url = reverse('subekashi:song_edit', args=[song.id])
         return mark_safe(f'<object><a href="{edit_url}">URL未登録</a></object>')
     
     # URLを登録しているのなら
-    for url in urls:
-        icon = get_all_media(url)["icon"]
-        i_tags += f'<a href="{url}" target="_blank">{icon}</a>'
+    for link in active_links:
+        icon = get_all_media(link.url)["icon"]
+        i_tags += f'<a href="{link.url}" target="_blank">{icon}</a>'
         
     return mark_safe(f'<object>{i_tags}</object>')
         

--- a/subekashi/views/song.py
+++ b/subekashi/views/song.py
@@ -13,11 +13,11 @@ def song(request, song_id):
     
     # URLのリンクを取得
     links = []
-    for url in song.url.split(",") if song.url else []:
-        media = get_all_media(url)
+    for link in song.links.all():
+        media = get_all_media(link.url)
         links.append(
             {
-                "text": url,
+                "text": link.url,
                 "icon": media["icon"],
                 "name": media["name"]
             }
@@ -56,7 +56,7 @@ def song(request, song_id):
     description += f"歌詞: {description_lyrics}" if description_lyrics else ""
     
     # 未完成かどうか
-    is_lack = Song.objects.filter(pk=song_id).filter(filter_by_lack).exists()
+    is_lack = Song.objects.filter(pk=song_id).filter(filter_by_lack()).exists()
     
     # タグを持っているかどうかの確認
     has_tag = any([

--- a/subekashi/views/song_edit.py
+++ b/subekashi/views/song_edit.py
@@ -45,7 +45,6 @@ def song_edit(request, song_id):
         cleaned_url_list = cleaned_url.split(",") if cleaned_url else []
         for cleaned_url_item in cleaned_url_list:
             # 既に登録されているURLの場合は(ユニークでなければ)エラー
-            # TODO URLテーブルで実装したい
             existing_song, _ = song_search({"url": cleaned_url_item})
             existing_song = list(existing_song)       # existsやfirstはエラーになるので使えない
             if url and existing_song and existing_song[0].id != song_id:
@@ -135,11 +134,14 @@ def song_edit(request, song_id):
                 info += f"{song.title}\n"
             return info[:-1]        # 最後の改行は不要
 
+        # URL変更前後の値を取得（SongLinkベース）
+        before_urls = ",".join(song.links.values_list('url', flat=True))
+
         # songを更新する前にhistoryのために更新前後のsongの情報を記録しておく
         COLUMNS = [
             {"label": "タイトル", "before": song.title ,"after": title},
             {"label": "作者", "before": song.authors_str(), "after": ", ".join([a.name for a in author_objects])},
-            {"label": "URL", "before": song.url ,"after": cleaned_url},
+            {"label": "URL", "before": before_urls ,"after": cleaned_url},
             {"label": "オリジナル", "before": yes_no(song.isoriginal) ,"after": yes_no(is_original)},
             {"label": "削除済み", "before": yes_no(song.isdeleted) ,"after": yes_no(is_deleted)},
             {"label": "ネタ曲", "before": yes_no(song.isjoke) ,"after": yes_no(is_joke)},
@@ -152,7 +154,6 @@ def song_edit(request, song_id):
 
         # songの更新
         song.title = title
-        song.url = cleaned_url
         song.lyrics = lyrics
         song.imitate = imitates
         song.isoriginal = is_original
@@ -166,7 +167,19 @@ def song_edit(request, song_id):
 
         # authorsフィールドの更新
         song.authors.set(author_objects)
-        
+
+        # SongLinkの更新（差分）
+        existing_links = {link.url: link for link in song.links.all()}
+        new_url_set = set(cleaned_url_list)
+        # 削除されたURLのSongLinkを削除
+        for url_str, link in existing_links.items():
+            if url_str not in new_url_set:
+                link.delete()
+        # 新規追加されたURLはSongLinkを作成
+        for url_str in new_url_set:
+            if url_str not in existing_links:
+                SongLink.objects.create(song=song, url=url_str)
+
         # History DBの変更内容とDisocrdの#新規作成・変更チャンネルに送る文の用意
         changes = [["種類", "編集前", "編集後"]]
         changed_labels = []

--- a/subekashi/views/song_new.py
+++ b/subekashi/views/song_new.py
@@ -82,7 +82,6 @@ def song_new(request):
         ip = get_ip(request)
         song = Song(
             title = title,
-            url = cleaned_url,
             post_time = timezone.now(),
             isoriginal = is_original,
             isdeleted = is_deleted,
@@ -98,6 +97,10 @@ def song_new(request):
 
         # authorsフィールドの更新
         song.authors.set(authors)
+
+        # SongLinkの作成
+        for url_str in cleaned_url.split(",") if cleaned_url else []:
+            SongLink.objects.create(song=song, url=url_str)
 
         song_id = song.id
         

--- a/subekashi/views/top.py
+++ b/subekashi/views/top.py
@@ -50,7 +50,7 @@ def top(request):
     # 未完成の表示設定
     lack_count = int(request.COOKIES.get("is_shown_lack", "5"))
     if lack_count > 0:
-        lackInsL = list(songInsL.filter(filter_by_lack))
+        lackInsL = list(songInsL.filter(filter_by_lack()))
         if lackInsL:
             lackInsL = random.sample(lackInsL, min(lack_count, len(lackInsL)))
             dataD["lackInsL"] = lackInsL


### PR DESCRIPTION
## Summary
- `query_filters.py`: `filter_by_keyword` / `filter_by_mediatypes` / `filter_by_lack` をSongLinkベースに変更
- `song_filterset.py`: `NEED_DISTINCT_KEY_LIST` に `'mediatypes'` 追加、`filter_by_lack()` 呼び出しに更新
- `song_card.py`: `get_url` タグを `song.links.all()` ベースに変更
- `views/song.py`: `song.url.split(',')` → `song.links.all()`
- `views/song_edit.py`: URL保存をSongLink差分更新に変更（削除分はSongLink削除、新規分は作成）
- `views/song_new.py`: Song保存後にSongLinkを作成、`song.url` への書き込みを削除
- `views/top.py`: `filter_by_lack()` 関数呼び出しに修正
- `management/commands/youtube.py`: `song.url` 参照をSongLinkに変更

## Test plan
- [ ] トップページ・検索ページで曲一覧が正常に表示される
- [ ] キーワード検索（URLを含む）が正常に動作する
- [ ] メディアタイプフィルターが正常に動作する
- [ ] islack フィルターが正常に動作する
- [ ] 曲詳細ページのURLリンクが正常に表示される
- [ ] 曲編集でURLを追加・変更・削除できる（SongLinkが作成・削除される）
- [ ] 曲新規登録でURLが登録される（SongLinkが作成される）

Closes #759

🤖 Generated with [Claude Code](https://claude.com/claude-code)