### PR TITLE
[SongLink DB] Phase 6: README.mdにurlフィールドのリスト形式を文書化

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,10 @@ python manage.py runserver
         },
         ...
       ],
+      "url": [
+        "https://youtu.be/VIDEO-00000",
+        "https://youtu.be/VIDEO-00001"
+      ],
       ...
     }
   ]
@@ -243,7 +247,7 @@ python manage.py runserver
 **個別取得時（/api/song/{song_id}）**
 ```json
 {
-  "song_id": 1,
+  "id": 1,
   "title": "曲名",
   "authors": [
     {
@@ -252,9 +256,16 @@ python manage.py runserver
     },
     ...
   ],
+  "url": [
+    "https://youtu.be/VIDEO-00000",
+    "https://youtu.be/VIDEO-00001"
+  ],
   ...
 }
 ```
+
+**`url`フィールドについて**
+`url`は登録されたURLの配列です。複数のURLが登録されている場合はすべて含まれます。URLが未登録の場合は空配列`[]`が返されます。
 
 ### Ad API
 **エンドポイント**: [https://lyrics.imicomweb.com/api/ad](https://lyrics.imicomweb.com/api/ad)


### PR DESCRIPTION
## 概要

`url`フィールドがSongLinkテーブルへの移行により文字列→配列に変わったため、README.mdのAPIドキュメントを更新。

## 変更内容

- 一覧取得・個別取得のレスポンス例に`url`フィールドを追加（配列形式で表示）
- `url`フィールドの説明を追記（複数URL対応、未登録時は空配列）

## 関連Issue

Closes #760

🤖 Generated with [Claude Code](https://claude.com/claude-code)