### PR TITLE
feat: [SongLink DB] Phase 9 - allow_dup許可リンクの追加 (#769)

### DIFF
--- a/subekashi/static/subekashi/js/song_edit.js
+++ b/subekashi/static/subekashi/js/song_edit.js
@@ -6,6 +6,8 @@ const lyricsEle = document.getElementById("lyrics")
 async function init() {
     openDeleteDetails();
     song_id = window.location.pathname.split("/")[2];
+    const allowDupUrl = new URLSearchParams(window.location.search).get('allow_dup_url');
+    if (allowDupUrl) document.getElementById('url').value = allowDupUrl;
     await checkTitleAuthorForm();
     await checkUrlForm();
     await initImitateList();
@@ -282,6 +284,7 @@ async function checkUrlForm() {
             const songLink = `${baseURL()}/songs/${song.id}`;
             const deleteReason = encodeURIComponent(`${songLink} と重複しています。`);
             const deleteLink = `${baseURL()}/songs/${song_id}/delete?reason=${deleteReason}`;
+            const allowDupLink = `?allow_dup_url=${encodeURIComponent(url)}`;
             songEditInfoUrlEle.innerHTML = `
             <span class="error">
                 <i class="fas fa-ban error"></i>
@@ -289,7 +292,8 @@ async function checkUrlForm() {
                 ${makeSongInfoRowsHTML([song])}<br>
                 として<a href="${songLink}" target="_blank">既に登録されています</a>${song.is_lack ? "がまだ未完成です。" : "。"}<br>
                 この記事を削除したい場合、<br>
-                <a href="${deleteLink}" target="_blank"><i class="error far fa-trash-alt"></i>削除申請</a>を行ってください。
+                <a href="${deleteLink}" target="_blank"><i class="error far fa-trash-alt"></i>削除申請</a>を行ってください。<br>
+                複数の曲があるURLとして登録したい場合、<br><a href="${allowDupLink}">こちら</a>をクリックしてください。
             </span>`;
             return;
         }

--- a/subekashi/static/subekashi/js/song_new.js
+++ b/subekashi/static/subekashi/js/song_new.js
@@ -1,6 +1,8 @@
 // 初期化
 const urlEle = document.getElementById('url');
 async function init() {
+    const allowDupUrl = new URLSearchParams(window.location.search).get('allow_dup_url');
+    if (allowDupUrl) urlEle.value = allowDupUrl;
     urlEle.focus();     // #urlにカーソルをあわせる
     await checkAutoForm();
     await checkManualForm();
@@ -67,7 +69,8 @@ async function checkAutoForm() {
     if (duplicateLinks.length) {
         const s = duplicateLinks[0].songs[0];
         const songUrl = `${baseURL()}/songs/${s.id}`;
-        newFormAutoInfoEle.innerHTML = `<span class='error'><i class='fas fa-ban error'></i>このURLは<br>${makeSongInfoRowsHTML([s])}<br>として<a href="${songUrl}" target="_blank">既に登録されています</a>${s.is_lack ? "がまだ未完成です" : ""}</span>`;
+        const allowDupLink = `?allow_dup_url=${encodeURIComponent(inputUrlEle)}`;
+        newFormAutoInfoEle.innerHTML = `<span class='error'><i class='fas fa-ban error'></i>このURLは<br>${makeSongInfoRowsHTML([s])}<br>として<a href="${songUrl}" target="_blank">既に登録されています</a>${s.is_lack ? "がまだ未完成です" : ""}<br>複数の曲があるURLとして登録したい場合、<br><a href="${allowDupLink}">こちら</a>をクリックしてください。</span>`;
         return;
     }
 

--- a/subekashi/views/song_edit.py
+++ b/subekashi/views/song_edit.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render, redirect
 from django.utils import timezone
 from django.urls import reverse
-from config.local_settings import NEW_DISCORD_URL
+from config.local_settings import NEW_DISCORD_URL, CONTACT_DISCORD_URL
 from config.settings import ROOT_URL
 from subekashi.models import *
 from subekashi.lib.url import *
@@ -233,4 +233,12 @@ def song_edit(request, song_id):
         response = redirect(f'/songs/{song_id}?toast=edit')
         response["X-Robots-Tag"] = "noindex, nofollow"
         return response
+    allow_dup_url = request.GET.get('allow_dup_url', '')
+    if allow_dup_url:
+        cleaned = clean_url(allow_dup_url) or allow_dup_url
+        link = SongLink.objects.filter(url__iexact=cleaned).first()
+        if link:
+            link.allow_dup = True
+            link.save()
+            send_discord(CONTACT_DISCORD_URL, f"重複許可したURL：{allow_dup_url}")
     return render(request, 'subekashi/song_edit.html', dataD)

--- a/subekashi/views/song_new.py
+++ b/subekashi/views/song_new.py
@@ -1,6 +1,7 @@
 from django.shortcuts import render, redirect
 from django.utils import timezone
 from config.settings import *
+from config.local_settings import CONTACT_DISCORD_URL
 from subekashi.models import *
 from subekashi.lib.url import *
 from subekashi.lib.ip import *
@@ -147,4 +148,12 @@ def song_new(request):
         
         # 登録できましたトーストを表示する
         return redirect(f'/songs/{song_id}/edit?toast={request.GET.get("toast")}')
+    allow_dup_url = request.GET.get('allow_dup_url', '')
+    if allow_dup_url:
+        cleaned = clean_url(allow_dup_url) or allow_dup_url
+        link = SongLink.objects.filter(url__iexact=cleaned).first()
+        if link:
+            link.allow_dup = True
+            link.save()
+            send_discord(CONTACT_DISCORD_URL, f"重複許可したURL：{allow_dup_url}")
     return render(request, 'subekashi/song_new.html', dataD)


### PR DESCRIPTION
## Summary

- `song_new.js` / `song_edit.js`: URL重複エラー時に「複数の曲があるURLとして登録したい場合、こちら」リンクを追加
  - クリックで `?allow_dup_url=<url>` 付き同ページにリロード
  - JSがリロード後に `allow_dup_url` パラメータからURLフォームに自動入力
- `song_new.py` / `song_edit.py`: GETで `allow_dup_url` パラメータを受け取り
  - 対象SongLinkの `allow_dup=True` に設定
  - Discord通知を送信（`CONTACT_DISCORD_URL`）

## Test plan

- [ ] URL重複エラーメッセージに「こちら」リンクが表示される
- [ ] リンクをクリックするとページがリロードされ、URLフォームに入力したURLが自動入力される
- [ ] リロード後、該当SongLinkの `allow_dup=True` になっている
- [ ] Discordに「重複許可したURL：{url}」が通知される
- [ ] リロード後の重複チェックで allow_dup=True の info メッセージが表示され登録可能になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)