### PR TITLE
feat: 記事内画像を中央寄せ・最大幅800pxでレスポンシブ対応

### DIFF
--- a/article/static/article/css/default_article.css
+++ b/article/static/article/css/default_article.css
@@ -34,9 +34,11 @@
 }
 
 #article-text img {
-    margin: 20px 0;
+    display: block;
+    margin: 20px auto;
     max-width: 800px;
-    width: 80vw;
+    width: 100%;
+    border: solid 2px #999;;
 }
 
 #article-text ul {


### PR DESCRIPTION
## Summary
- 記事内の画像に `display: block` を追加し、`margin: auto` による中央寄せを有効化
- `width: 100%` を追加し、画面幅が800px以下の場合に左右均等マージンを保ちながら縮小表示

## Test plan
- [ ] 画像が中央に表示されることを確認
- [ ] 画面幅800px以上では最大幅800pxで表示されることを確認
- [ ] 画面幅800px未満では左右均等のマージンで縮小表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)