### PR TITLE
fix: song_guesserのescapejsによる文字化けを修正

### DIFF
--- a/subekashi/templates/subekashi/components/song_guesser.html
+++ b/subekashi/templates/subekashi/components/song_guesser.html
@@ -1,4 +1,4 @@
 <div class="song-guesser" onclick=songGuesserClick({{ song.id }})>
-    <p><span class="author"><i class="fas fa-user-circle"></i> {{ song.authors.all|join:','|escapejs }}</span>
-    <i class="fas fa-music"></i> {{ song.title|escapejs }}</p>
+    <p><span class="author"><i class="fas fa-user-circle"></i> {{ song.authors.all|join:',' }}</span>
+    <i class="fas fa-music"></i> {{ song.title }}</p>
 </div>


### PR DESCRIPTION
## Summary
- `song_guesser.html` で `escapejs` フィルターが誤用されており、ハイフン(`-`)が `\u002D` などのユニコードエスケープとして画面に表示されてしまう問題を修正
- `escapejs` はJavaScript文字列リテラル用のエスケープであり、HTML出力には不適切。Djangoのデフォルト自動HTMLエスケープに置き換えた

## Test plan
- [ ] `api/html/song_guessers` でハイフンを含む曲名・作者名が正しく表示されることを確認
- [ ] XSS等のセキュリティ上の問題がないことを確認（Djangoのデフォルト自動エスケープが適用されているため問題なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)