### PR TITLE
feat: 登録ボタンクリック時にローディング表示とボタン無効化

### DIFF
--- a/subekashi/static/subekashi/js/song_new.js
+++ b/subekashi/static/subekashi/js/song_new.js
@@ -178,3 +178,13 @@ titleEle.addEventListener('input', checkManualForm);
 window.addEventListener("pageshow", function () {
     init();
 });
+
+// 登録ボタンクリック時の処理
+['new-form-auto', 'new-form-manual'].forEach(formId => {
+    document.getElementById(formId).addEventListener('submit', function () {
+        const submitBtn = this.querySelector('input[type="submit"]');
+        const infoEle = document.getElementById(formId + '-info');
+        submitBtn.disabled = true;
+        infoEle.innerHTML = `<span class="loading"></span>`;
+    });
+});


### PR DESCRIPTION
## Summary
- 登録ボタンをクリック（フォームをsubmit）したとき、`.loading` スピナーをinfo欄に表示する
- 押した登録ボタンを `disabled` にして二重送信を防ぐ
- `new-form-auto`・`new-form-manual` 両フォームに対応

## Test plan
- [ ] YouTubeリンクフォームの「登録」ボタンをクリック → ローディング表示・ボタン無効化を確認
- [ ] 曲名・作者フォームの「登録」ボタンをクリック → ローディング表示・ボタン無効化を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)