### PR TITLE
fix: keywordでYouTube動画IDを検索した際にURLがヒットしない問題を修正 (#805)

### DIFF
--- a/subekashi/lib/query_filters.py
+++ b/subekashi/lib/query_filters.py
@@ -5,16 +5,13 @@ from subekashi.models import Author, SongLink
 
 # topやsearchにあるキーワード検索のフィルター
 def filter_by_keyword(keyword):
-    q = (
-        Q(title__contains = keyword) |
-        Q(authors__name__contains = keyword) |
-        Q(lyrics__contains = keyword)
-    )
-    # URLっぽいキーワード（://を含む）の場合のみSongLinkも検索
     url_keyword = clean_url(keyword)
-    if '://' in url_keyword:
-        q |= Q(links__url__icontains=url_keyword)
-    return q
+    return (
+        Q(title__contains=keyword) |
+        Q(authors__name__contains=keyword) |
+        Q(lyrics__contains=keyword) |
+        Q(links__url__icontains=url_keyword)
+    )
 
 # 模倣元のフィルター
 def filter_by_imitate(imitate):


### PR DESCRIPTION
## Summary
- `filter_by_keyword` でURLフィールドの検索を `://` を含む場合のみに制限していた条件を削除
- 常に `links__url__icontains` でURL検索するよう修正
- これにより `video000000` のような動画IDのみのキーワードで `https://youtu.be/video000000` がヒットするようになった

## Test plan
- [ ] keyword=`video000000` で `https://youtu.be/video000000` を持つレコードがフィルターされることを確認
- [ ] keyword=`https://youtu.be/video000000` の動作が引き続き正常であることを確認
- [ ] keyword=`タイトル名` など通常のキーワード検索が引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)