### PR TITLE
[Fix] collectstatic重複警告の修正

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -5,9 +5,7 @@ from .local_settings import *
 BASE_DIR = Path(__file__).resolve().parent.parent
 STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
-STATICFILES_DIRS = [
-    os.path.join(BASE_DIR, "subekashi" ,"static"),
-]
+STATICFILES_DIRS = []
 
 ROOT_URL = "http://subekashi.localhost:8000" if DEBUG else "https://lyrics.imicomweb.com"
 


### PR DESCRIPTION
## Summary
- `STATICFILES_DIRS` から `subekashi/static` の重複エントリを削除
- `subekashi` は `INSTALLED_APPS` に登録済みのため `AppDirectoriesFinder` が自動収集するが、`STATICFILES_DIRS` にも同じパスを指定していたため `collectstatic` 時に重複警告が発生していた

## Test plan
- [ ] `python manage.py collectstatic` を実行して警告が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)