### PR TITLE
[Feature] 動的定数ファイルをPythonからJSONに移行 (#801)

### DIFF
--- a/subekashi/management/commands/const.py
+++ b/subekashi/management/commands/const.py
@@ -7,13 +7,12 @@ class Command(BaseCommand):
     help = "定数ファイルの生成。すでにあるファイルは上書きしない。"
     
     def handle(self, *args, **options) :
-        # TODO pyファイルではなくjsonファイルにする
         CONST_INFO = {
-            'ai.py': 'GENEINFO = {\n\t"WORD_COUNT": 1440480,\n\t"SONG_COUNT": 3000,\n\t"GENE_DATE": "2024年9月9日",\n}',
-            'ban.py': 'BAN_LIST = []',
+            'ai.json': '{\n\t"WORD_COUNT": 1440480,\n\t"SONG_COUNT": 3000,\n\t"GENE_DATE": "2024年9月9日"\n}',
+            'ban.json': '[]',
             'gpt.txt': '',
             'version.json': '{\n\t"VERSION": "dev"\n}',
-            'reject.py': 'REJECT_LIST = []',
+            'reject.json': '[]',
             'maintenance.json': '{\n\t"IS_MAINTENANCE": false,\n\t"MAINTENANCE_MASSAGE": "<p>メンテナンス中です</p>"\n}',
         }
         for file_name, text in CONST_INFO.items():

--- a/subekashi/middleware/restrict_ip.py
+++ b/subekashi/middleware/restrict_ip.py
@@ -1,3 +1,5 @@
+import json
+import os
 from django.shortcuts import render
 from config.settings import *
 from subekashi.lib.ip import get_ip
@@ -6,11 +8,11 @@ class RestrictIPMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
         try:
-            from subekashi.constants.dynamic.ban import BAN_LIST
-        except :
+            ban_path = os.path.join(BASE_DIR, 'subekashi/constants/dynamic/ban.json')
+            with open(ban_path, "r", encoding="utf-8") as f:
+                self.BAN_LIST = json.load(f)
+        except:
             self.BAN_LIST = []
-        else:
-            self.BAN_LIST = BAN_LIST
 
     def __call__(self, request):
         ip = get_ip(request, raw=True)

--- a/subekashi/views/ai.py
+++ b/subekashi/views/ai.py
@@ -1,8 +1,13 @@
+import json
+import os
 from django.shortcuts import render
+from config.settings import BASE_DIR
 from subekashi.models import *
 from subekashi.lib.url import *
 from subekashi.lib.discord import *
 from subekashi.constants.constants import CONST_ERROR
+
+AI_JSON_PATH = os.path.join(BASE_DIR, 'subekashi/constants/dynamic/ai.json')
 
 
 def ai(request) :
@@ -11,8 +16,9 @@ def ai(request) :
     }
     
     try:
-        from subekashi.constants.dynamic.ai import GENEINFO
-    except :
+        with open(AI_JSON_PATH, "r", encoding="utf-8") as f:
+            GENEINFO = json.load(f)
+    except:
         send_discord(ERROR_DISCORD_URL, CONST_ERROR)
         GENEINFO = {}
     dataD.update(GENEINFO)

--- a/subekashi/views/song_edit.py
+++ b/subekashi/views/song_edit.py
@@ -1,8 +1,10 @@
+import json
+import os
 from django.shortcuts import render, redirect
 from django.utils import timezone
 from django.urls import reverse
 from config.local_settings import NEW_DISCORD_URL, CONTACT_DISCORD_URL
-from config.settings import ROOT_URL
+from config.settings import ROOT_URL, BASE_DIR
 from subekashi.models import *
 from subekashi.lib.url import *
 from subekashi.lib.ip import *
@@ -82,7 +84,9 @@ def song_edit(request, song_id):
         
         # 掲載拒否リストの読み込み
         try:
-            from subekashi.constants.dynamic.reject import REJECT_LIST
+            reject_path = os.path.join(BASE_DIR, 'subekashi/constants/dynamic/reject.json')
+            with open(reject_path, "r", encoding="utf-8") as f:
+                REJECT_LIST = json.load(f)
         except:
             REJECT_LIST = []
         

--- a/subekashi/views/song_new.py
+++ b/subekashi/views/song_new.py
@@ -1,3 +1,5 @@
+import json
+import os
 from django.shortcuts import render, redirect
 from django.utils import timezone
 from config.settings import *
@@ -68,7 +70,9 @@ def song_new(request):
 
         # 掲載拒否リストの読み込み
         try:
-            from subekashi.constants.dynamic.reject import REJECT_LIST
+            reject_path = os.path.join(BASE_DIR, 'subekashi/constants/dynamic/reject.json')
+            with open(reject_path, "r", encoding="utf-8") as f:
+                REJECT_LIST = json.load(f)
         except:
             REJECT_LIST = []
 


### PR DESCRIPTION
## Summary
- `ai.py` / `ban.py` / `reject.py` を `ai.json` / `ban.json` / `reject.json` に置き換え
- 参照箇所（`views/ai.py`, `views/song_new.py`, `views/song_edit.py`, `middleware/restrict_ip.py`）を `json.load()` による読み込みに書き換え
- `management/commands/const.py` も新しい JSON ファイルを生成するよう更新

## Test plan
- [ ] `python manage.py const` を実行して `ai.json` / `ban.json` / `reject.json` が生成されることを確認
- [ ] AI ページ (`/ai`) が正常に表示されることを確認
- [ ] 曲の新規登録・編集で掲載拒否リストが正常に動作することを確認
- [ ] BAN リストが IP 制限に正常に適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)