### PR TITLE
[Refactor] div.underlineをh1::afterに置き換え

### DIFF
--- a/article/templates/article/anniversary6.html
+++ b/article/templates/article/anniversary6.html
@@ -7,7 +7,6 @@
 {% block content %}
 <section id="anniversary6">
     <h1>6周年記念グラフィックアート</h1>
-    <div class="underline"></div>
     <p>全てあなたの所為です。6周年を記念して、全て歌詞の所為です。のデータベースを用いて製作されたグラフィックアートを公開します。</p>
     {% for image in images %}
         <div class="img-div" id="{{ image }}">

--- a/article/templates/article/articles.html
+++ b/article/templates/article/articles.html
@@ -7,7 +7,6 @@
 {% block content %}
 <section>
     <h1>記事一覧</h1>
-    <div class="underline"></div>
     <form method="get" action=".">
         <div class="form-col">
             <label for="tag">タグ</label>

--- a/article/templates/article/default_article.html
+++ b/article/templates/article/default_article.html
@@ -7,7 +7,6 @@
 {% block content %}
 <section>
     <h1 id="article-title">{{ article.title|safe }}</h1>
-    <div class="underline"></div>
     <p id="article-info">
         <i class="fas fa-user"></i>
         {{ article.author }}

--- a/subekashi/static/subekashi/css/common.css
+++ b/subekashi/static/subekashi/css/common.css
@@ -390,7 +390,16 @@ h1 {
     color: #FFF;
     font-size: 40px;
     font-weight: lighter;
-    margin: 60px 0 5px 0;
+    margin: 60px 0 0 0;
+}
+
+h1::after {
+    content: "";
+    display: block;
+    height: 8px;
+    width: 150px;
+    margin: 5px auto 25px auto;
+    background-color: #fff;
 }
 
 h2 {
@@ -464,16 +473,8 @@ a {
     margin-right: 10px;
 }
 
-.underline {
-    text-align: center;
-    height: 8px;
-    width: 150px;
-    margin: 0 auto 25px auto;
-    background-color: #fff;
-}
-
 @media (max-width: 640px) {
-    .underline {
+    h1::after {
         margin-bottom: 15px;
     }
 }

--- a/subekashi/templates/subekashi/ad.html
+++ b/subekashi/templates/subekashi/ad.html
@@ -7,7 +7,6 @@
 {% block content %}
 <section>
     <h1>すべかしDSP</h1>
-    <div class="underline"></div>
     {% comment %} TODO blogにまとめる {% endcomment %}
     <details>
         <summary><i class="fas fa-bars"></i>すべかしDSPの使い方</summary>

--- a/subekashi/templates/subekashi/ai.html
+++ b/subekashi/templates/subekashi/ai.html
@@ -7,7 +7,6 @@
 {% block content %}
 <section id="ai-section">
     <h1>正常に狂うのです。</h1>
-    <div class="underline"></div>
     <form action="{% url 'subekashi:ai_result' %}" method="POST">{% csrf_token %}
         <input type="submit" value="生成">
         <p>総学習量: {{ WORD_COUNT }}文字({{ SONG_COUNT }}曲)</p>
@@ -15,9 +14,7 @@
         <p>対象: 全すべあな界隈曲</p>
     </form>
 
-    {% comment %} TODO underlineをh1にマージ {% endcomment %}
     <h1>最高評価の歌詞</h1>
-    <div class="underline"></div>
     {% for bestIns in bestInsL  %}
         <p class="lyric">{{ bestIns.lyrics }}</p>
     {% endfor %}

--- a/subekashi/templates/subekashi/ai_result.html
+++ b/subekashi/templates/subekashi/ai_result.html
@@ -7,7 +7,6 @@
 {% block content %}
 <section>
     <h1>歌詞の生成結果</h1>
-    <div class="underline"></div>
     {% for aiIns in aiInsL  %}
         <div class="ai-ins">
             <p class="lyric">{{ aiIns.lyrics }}</p>

--- a/subekashi/templates/subekashi/author.html
+++ b/subekashi/templates/subekashi/author.html
@@ -8,7 +8,6 @@
 {% block content %}
 <section>
     <h1>{{ author }}</h1>
-    <div class="underline"></div>
     {% for songIns in songInsL %}
         {% render_song_card songIns %}
     {% empty %}

--- a/subekashi/templates/subekashi/contact.html
+++ b/subekashi/templates/subekashi/contact.html
@@ -5,7 +5,6 @@
 {% block content %}
 <section>
     <h1>お問い合わせ</h1>
-    <div class="underline"></div>
 
     <form action="{% url 'subekashi:contact' %}" method="POST" id="contact-form">{% csrf_token %}
         <div class="form-col">
@@ -32,7 +31,6 @@
         </p>
     </form>
     <h1>返信一覧</h1>
-    <div class="underline"></div>
     {% for contact in contact_qs %}
         <div class="contact">
             <p class="meta">No. {{ contact.id }}　投稿日：{{ contact.post_time }}</p>

--- a/subekashi/templates/subekashi/editor.html
+++ b/subekashi/templates/subekashi/editor.html
@@ -9,7 +9,6 @@
 {% block content %}
 <section>
     <h1><span id="h1-title">{{ editor }}{% if is_me %}(あなた){% endif %}の編集履歴</span></h1>
-    <div class="underline"></div>
     {% if editor.is_open or editor.is_forced_open or is_me %}
         {% if not editor.is_open and not editor.is_forced_open %}
             <p id="private_info">この情報はあなただけに表示されています。</p>

--- a/subekashi/templates/subekashi/setting.html
+++ b/subekashi/templates/subekashi/setting.html
@@ -7,7 +7,6 @@
 {% block content %}
 <section>
     <h1>設定</h1>
-    <div class="underline"></div>
 
     {% with top_settings=settings.top search_settings=settings.search song_settings=settings.song edit_settings=settings.edit %}
     <h2>トップ画面</h2>

--- a/subekashi/templates/subekashi/song_edit.html
+++ b/subekashi/templates/subekashi/song_edit.html
@@ -37,7 +37,6 @@
     </details>
 
     <h1><span id="h1-title">{{ song.title }}</span>の編集</h1>
-    <div class="underline"></div>
     <form action="{% url 'subekashi:song_edit' song.id %}" method="POST" id="song-edit-form">{% csrf_token %}
         {% comment %} TODO 別名の入力項目を追加 {% endcomment %}
         <div class="form-col">

--- a/subekashi/templates/subekashi/song_history.html
+++ b/subekashi/templates/subekashi/song_history.html
@@ -9,7 +9,6 @@
 {% block content %}
 <section>
     <h1><span id="h1-title">{{ song.title }}</span>の編集履歴</h1>
-    <div class="underline"></div>
     <div class="dummybuttons">
         <a href="{% url 'subekashi:song' song.id %}">
             <div class="dummybutton"><i class="fab fa-itunes-note"></i><p>曲の詳細</p></div>

--- a/subekashi/templates/subekashi/song_new.html
+++ b/subekashi/templates/subekashi/song_new.html
@@ -17,7 +17,6 @@
     </details>
 
     <h1>YouTubeの動画リンクから登録<i class="fas fa-info-circle" onclick="showTutorial('new-form-auto')"></i></h1>
-    <div class="underline"></div>
     <form action="{% url 'subekashi:song_new' %}?toast=auto" method="POST" id="new-form-auto">{% csrf_token %}
         <div class="form-col">
             <label for="url">YouTubeの<br>動画リンク<i class="fas fa-info-circle" onclick="showTutorial('youtube-url')"></i></label>
@@ -53,7 +52,6 @@
     </form>
     
     <h1>曲名と作者から登録<i class="fas fa-info-circle" onclick="showTutorial('new-form-manual')"></i></h1>
-    <div class="underline"></div>
     <form action="{% url 'subekashi:song_new' %}?toast=manual" method="POST" id="new-form-manual">{% csrf_token %}
         <div class="form-col">
             <label for="title">曲名<i class="fas fa-info-circle" onclick="showTutorial('title')"></i></label>
@@ -93,7 +91,6 @@
     </form>
 
     <h1>???から登録<i class="fas fa-info-circle" onclick="showToast('', '<span style=\'color: red;\'>~~~@z@ÆÐäÞÚÊ엂빪풾𐇺</span>');"></i></h1>
-    <div class="underline"></div>
 </section>
 {% endblock %}
 

--- a/subekashi/templates/subekashi/songs.html
+++ b/subekashi/templates/subekashi/songs.html
@@ -9,7 +9,6 @@
 {% block content %}
 <section>
     <h1>曲の一覧と検索</h1>
-    <div class="underline"></div>
 
     <div class="form-col">
         <label for="keyword">キーワード</label>

--- a/subekashi/templates/subekashi/top.html
+++ b/subekashi/templates/subekashi/top.html
@@ -7,7 +7,6 @@
 <section>
     {% if request.COOKIES.news_type != "off" %}
         <h1>ニュース</h1>
-        <div class="underline"></div>
         {% if request.COOKIES.news_type == "single" or not request.COOKIES.news_type %}
             <div id="single-news-wrapper">
                 <div id="single-news-display">
@@ -22,7 +21,6 @@
     {% endif %}
     {% if request.COOKIES.is_shown_search != "off" %}
         <h1>検索</h1>
-        <div class="underline"></div>
         <form action="{% url 'subekashi:songs' %}" method="GET" id="search-form">
             <div class="form-col">
                 <label for="keyword">キーワード</label>
@@ -34,7 +32,6 @@
 
     {% if songInsL %}
         <h1>新着</h1>
-        <div class="underline"></div>
         {% for songIns in songInsL %}
             {% render_song_card songIns %}
         {% endfor %}
@@ -46,7 +43,6 @@
     
     {% if is_shown_ad %}
         <h1>宣伝</h1>
-        <div class="underline"></div>
         <div class="youtube" id="ad">
             <iframe id="player" src="https://www.youtube-nocookie.com/embed/{{ adIns.url | slice:'17:' }}?enablejsapi=1" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreenframeborder="0"></iframe>
         </div>
@@ -58,7 +54,6 @@
 
     {% if aiInsL and request.COOKIES.is_shown_ai != "off" %}
         <h1>生成された歌詞</h1>
-        <div class="underline"></div>
         {% for aiIns in aiInsL %}
             <p class="lyrics">{{ aiIns.lyrics }}</p>
         {% endfor %}
@@ -69,7 +64,6 @@
 
     {% if lackInsL %}
         <h1>未完成</h1>
-        <div class="underline"></div>
         {% for songIns in lackInsL %}
             {% render_song_card songIns %}
         {% endfor %}
@@ -80,7 +74,6 @@
     {% endif %}
  
     <h1>リンク</h1>
-    <div class="underline"></div>
     <h2>全て歌詞の所為です。</h2>
     <div id="subekashi-links">
         <a href="https://youtube.com/@subekashi" target="_blank"><i class="fab fa-youtube"></i></a>
@@ -93,7 +86,6 @@
         <a href="https://www.youtube.com/@subeteanatanoseidesu" id="subeana" target="_blank">全てあなたの所為です。</a>
     </div>
     <h1>クレジット</h1>
-    <div class="underline"></div>
     <div id="credit">
         <p>本ソフトでは表示フォントに「源全ゴシック」(<a href="https://drive.google.com/drive/folders/19WidrJoCmI5qLJV-eR_ydURIwxB2-DSH" target="_blank">https://drive.google.com/drive/folders/19WidrJoCmI5qLJV-eR_ydURIwxB2-DSH</a>) を使用しています。</p>
         <p>Licensed under SIL Open Font License 1.1 <a href="http://scripts.sil.org/OFL" target="_blank">http://scripts.sil.org/OFL</a></p>


### PR DESCRIPTION
## Summary
- `<div class="underline"></div>` を全テンプレート（16ファイル）から削除
- `h1::after` 擬似要素に同等のレイアウト（height: 8px, width: 150px, background: #fff）を追加
- `common.css` から `.underline` クラスの定義を削除

## Test plan
- [ ] 各ページのh1下にアンダーライン装飾が表示されることを確認
- [ ] モバイル（640px以下）でmargin-bottomが15pxになることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)