### PR TITLE
[Feature] 設定画面からPCメニューの表示位置をheader/asideで切り替え可能に

### DIFF
--- a/subekashi/lib/context_processors.py
+++ b/subekashi/lib/context_processors.py
@@ -25,6 +25,7 @@ def context_processors(request):
         "version": version,
         "is_maintenance": maintenance.get("IS_MAINTENANCE", False),
         "maintenance_message": maintenance.get("MAINTENANCE_MESSAGE", "<p>メンテナンス中です</p>"),
+        "pc_menu_position": request.COOKIES.get("pc_menu_position", "header"),
     }
 
     return context

--- a/subekashi/static/subekashi/css/common.css
+++ b/subekashi/static/subekashi/css/common.css
@@ -47,17 +47,17 @@ header {
 }
 
 @media (min-width: 961px) {
-    header {
+    body[data-pc-menu="header"] header {
         position: sticky;
         top: -90px; /* -(#pc-global-items-wrapper 30px + #subekashi-header-top 60px) */
     }
 
-    header:has(#pc-header-menu:hover) {
+    body[data-pc-menu="header"] header:has(#pc-header-menu:hover) {
         border-bottom-color: #000;
         transition-delay: 0.2s;
     }
 
-    #subekashi-header {
+    body[data-pc-menu="header"] #subekashi-header {
         padding-bottom: 48px; /* #pc-header-menu のアイコン行の高さ分を確保 */
     }
 }
@@ -265,6 +265,77 @@ header {
 #pc-header-menu .fa-robot {
     margin-left: -2px !important;
     margin-right: 2px !important;
+}
+
+
+/* PCサイドメニュー (aside位置の場合) */
+body[data-pc-menu="aside"] aside {
+    display: block;
+    position: fixed;
+    top: 50%;
+    transform: translateY(-50%);
+    left: 0;
+    font-size: 32px;
+    width: 1.25em;
+    overflow-x: hidden;
+    background-color: #111111aa;
+    z-index: 99;
+    transition: all 300ms 0s ease;
+}
+
+@media (max-width: 960px) {
+    body[data-pc-menu="aside"] aside {
+        display: none;
+    }
+}
+
+body[data-pc-menu="aside"] aside:hover {
+    width: 7.5em;
+}
+
+body[data-pc-menu="aside"] aside table {
+    border: 0px none;
+    width: 100%;
+    border-spacing: 0;
+}
+
+body[data-pc-menu="aside"] aside td {
+    padding: 2px 0;
+}
+
+body[data-pc-menu="aside"] aside tr:hover {
+    background-color: #ffffff33;
+}
+
+body[data-pc-menu="aside"] aside a {
+    display: flex;
+    align-items: center;
+    white-space: nowrap;
+    text-decoration: none;
+}
+
+body[data-pc-menu="aside"] aside i {
+    width: 1em;
+    margin: 0.5em;
+    text-align: center;
+    flex-shrink: 0;
+}
+
+body[data-pc-menu="aside"] aside p {
+    display: inline-block;
+    font-size: 22px;
+    opacity: 0;
+    margin-left: -10px;
+    transition: all 300ms 0s ease;
+}
+
+body[data-pc-menu="aside"] aside:hover p {
+    margin-left: 0;
+    opacity: 1;
+}
+
+body[data-pc-menu="aside"] aside a:hover p {
+    text-decoration: underline 2px #fff;
 }
 
 

--- a/subekashi/templates/subekashi/base/aside.html
+++ b/subekashi/templates/subekashi/base/aside.html
@@ -1,0 +1,15 @@
+{% load static %}
+
+
+<aside>
+    <table>
+    {% for aside_page in aside_pages %}
+        <tr>
+            <td><a class="sansfont" href="{% url aside_page.url %}"><i class="{{ aside_page.icon }}"></i><p>{{ aside_page.name }}</p></a></td>
+        </tr>
+    {% endfor %}
+        <tr>
+            <td><a href="https://www.youtube.com/@subeteanatanoseidesu" target="_blank"><i class="far fa-user"></i><p>全てあなたの所為です。</p></a></td>
+        </tr>
+    </table>
+</aside>

--- a/subekashi/templates/subekashi/base/base.html
+++ b/subekashi/templates/subekashi/base/base.html
@@ -28,8 +28,11 @@
         <link rel="shortcut icon" href="{% static 'subekashi/image/icon.ico' %}">
         <link rel="apple-touch-icon" href="{% static 'subekashi/image/apple-touch-icon.png' %}">
     </head>
-    <body>
+    <body data-pc-menu="{{ pc_menu_position }}">
         {% include './header.html' %}
+        {% if pc_menu_position == "aside" %}
+            {% include './aside.html' %}
+        {% endif %}
         <main>
             {% get_toast toast_type toast_text %}
             <div id="toast-container"></div>

--- a/subekashi/templates/subekashi/base/header.html
+++ b/subekashi/templates/subekashi/base/header.html
@@ -28,6 +28,8 @@
                 <a href="{% url 'subekashi:top' %}">全て歌詞の所為です。</a>
             {% endif %}
         </div>
-        {% include './pc_menu.html' %}
+        {% if pc_menu_position == "header" %}
+            {% include './pc_menu.html' %}
+        {% endif %}
     </div>
 </header>

--- a/subekashi/templates/subekashi/setting.html
+++ b/subekashi/templates/subekashi/setting.html
@@ -8,7 +8,19 @@
 <section>
     <h1>設定</h1>
 
-    {% with top_settings=settings.top search_settings=settings.search song_settings=settings.song edit_settings=settings.edit %}
+    {% with top_settings=settings.top search_settings=settings.search song_settings=settings.song display_settings=settings.display edit_settings=settings.edit %}
+    <h2>表示設定</h2>
+    {% for setting in display_settings %}
+        <div class="form-col">
+            <label>{{ setting.label }}</label>
+            <select id="{{ setting.id }}" class="setting-input">
+                {% for option in setting.options %}
+                <option value="{{ option.value }}" {% if option.selected %}selected{% endif %}>{{ option.text }}</option>
+                {% endfor %}
+            </select>
+        </div>
+    {% endfor %}
+
     <h2>トップ画面</h2>
     {% for setting in top_settings %}
         <div class="form-col">
@@ -102,6 +114,11 @@
 
         // 変更された設定を即座に保存
         await saveSingleSetting(input.id, input.value);
+
+        // メニュー位置の変更はサーバーサイドレンダリングのためページリロードが必要
+        if (input.id === 'pc_menu_position') {
+            location.reload();
+        }
     }
 
     async function saveSingleSetting(key, value) {

--- a/subekashi/views/setting.py
+++ b/subekashi/views/setting.py
@@ -10,7 +10,7 @@ import json
 ALLOWED_SETTING_KEYS = {
     'songrange', 'jokerange', 'news_type', 'is_shown_search',
     'is_shown_new', 'is_shown_ad', 'is_shown_ai', 'is_shown_lack',
-    'is_saved_select', 'brlyrics'
+    'is_saved_select', 'brlyrics', 'pc_menu_position'
 }
 
 # 各設定の許可される値
@@ -24,7 +24,8 @@ ALLOWED_SETTING_VALUES = {
     'is_shown_ai': {'on', 'off'},
     'is_shown_lack': {'0', '5', '10', '15'},
     'is_saved_select': {'on', 'off'},
-    'brlyrics': {'normal', 'pack', 'brless'}
+    'brlyrics': {'normal', 'pack', 'brless'},
+    'pc_menu_position': {'header', 'aside'}
 }
 
 
@@ -43,6 +44,7 @@ def setting(request):
     is_shown_lack = request.COOKIES.get("is_shown_lack", "5")
     is_saved_select = request.COOKIES.get("is_saved_select", "on")
     brlyrics = request.COOKIES.get("brlyrics", "normal")
+    pc_menu_position = request.COOKIES.get("pc_menu_position", "header")
 
     settings_data = {
         'top': [
@@ -135,6 +137,16 @@ def setting(request):
                     {'value': 'normal', 'text': '全ての改行を表示', 'selected': brlyrics == 'normal'},
                     {'value': 'pack', 'text': '連続した改行を非表示', 'selected': brlyrics == 'pack'},
                     {'value': 'brless', 'text': '全ての改行を非表示', 'selected': brlyrics == 'brless'},
+                ]
+            },
+        ],
+        'display': [
+            {
+                'label': 'PCメニューの位置',
+                'id': 'pc_menu_position',
+                'options': [
+                    {'value': 'header', 'text': 'トップ', 'selected': pc_menu_position == 'header'},
+                    {'value': 'aside', 'text': 'サイド', 'selected': pc_menu_position == 'aside'},
                 ]
             },
         ],


### PR DESCRIPTION
## Summary
- 設定画面（表示設定セクション）から PCメニューの表示位置を **ヘッダー** と **サイド** で切り替え可能に
- サイド選択時は PR #822 以前の左固定サイドバー（ホバーで展開）を復元
- ヘッダー選択時は PR #826 のヘッダー展開メニューを表示
- cookie `pc_menu_position` に保存され、変更直後にページリロードで即時反映

## 変更内容
- `aside.html` を復元（PR #822 で削除されたサイドバーテンプレート）
- `context_processors.py` に `pc_menu_position` を追加しすべてのテンプレートで参照可能に
- `base.html` に `data-pc-menu` 属性を追加、asideモード時に `aside.html` をインクルード
- `header.html` の `pc_menu.html` インクルードを headerモード時のみに限定
- `common.css` のstickyヘッダーCSSを `body[data-pc-menu="header"]` にスコープ化し、aside CSSを復元
- `setting.py` に `pc_menu_position` 設定を追加（ホワイトリスト・バリデーション含む）
- `setting.html` に「表示設定」セクションを最上部に追加

## Test plan
- [ ] 設定画面の「表示設定 > PCメニューの位置」で「サイド」を選択 → ページリロード後に左サイドバーが表示される
- [ ] サイドバーにホバーするとメニューが展開される
- [ ] 設定画面の「表示設定 > PCメニューの位置」で「ヘッダー（トップ）」を選択 → ヘッダーメニューに戻る
- [ ] SP（960px以下）ではasideが非表示になる
- [ ] cookie `pc_menu_position` がブラウザに保存される

🤖 Generated with [Claude Code](https://claude.com/claude-code)