### PR TITLE
[Refactor] sp_menu.htmlのメニューリンクをASIDE_PAGES定数を利用したforループに変更

### DIFF
--- a/subekashi/templates/subekashi/base/sp_menu.html
+++ b/subekashi/templates/subekashi/base/sp_menu.html
@@ -2,15 +2,9 @@
 
 
 <div id="sp_menu" class="sansfont">
-    <a href="{% url 'subekashi:top' %}"><i class="fas fa-home"></i><p>トップ</p></a>
-    <a href="{% url 'subekashi:song_new' %}"><i class="fa fa-plus"></i><p>新規登録</p></a>
-    <a href="{% url 'subekashi:songs' %}"><i class="fas fa-search"></i><p>検索</p></a>
-    <a href="{% url 'subekashi:histories' %}"><i class="fas fa-pen"></i><p>編集履歴</p></a>
-    <a href="{% url 'subekashi:ai' %}"><i class="fa fa-robot"></i><p>歌詞生成</p></a>
-    <a href="{% url 'subekashi:ad' %}"><i class="fas fa-bullhorn"></i><p>宣伝</p></a>
-    <a href="{% url 'article:articles' %}"><i class="fas fa-book"></i><p>記事</p></a>
-    <a href="{% url 'subekashi:contact' %}"><i class="fas fa-envelope"></i><p>お問い合わせ</p></a>
-    <a href="{% url 'subekashi:setting' %}"><i class="fas fa-cog"></i><p>設定</p></a>
+    {% for aside_page in aside_pages %}
+    <a href="{% url aside_page.url %}"><i class="{{ aside_page.icon }}"></i><p>{{ aside_page.name }}</p></a>
+    {% endfor %}
     <a href="https://www.youtube.com/@subeteanatanoseidesu" target="_blank"><i class="far fa-user"></i><p>全てあなたの所為です。</p></a>
     <p id="sp_version"><i class="fa fa-history"></i> <span id="version">{{ version }}</span></p>
     <div id="sp-global-header">


### PR DESCRIPTION
## Summary
- `sp_menu.html` のハードコードされた9つのメニューリンクを削除
- `pc_menu.html` / `aside.html` と同様に `aside_pages` コンテキスト変数のforループに置き換え
- `ASIDE_PAGES` 定数の変更が全メニューに一括反映されるようになった

## Test plan
- [ ] スマホメニューの各リンクが正しく表示されること
- [ ] `ASIDE_PAGES` の変更が `sp_menu.html` にも反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)