### PR TITLE
[Refactor] デフォ子ロゴを日付条件から1/10000の確率表示に変更

### DIFF
--- a/subekashi/static/subekashi/js/base.js
+++ b/subekashi/static/subekashi/js/base.js
@@ -457,4 +457,17 @@ function autoScroll(deley) {
 // 読み込み時の実行
 window.onload = function() {
     getGlobalHeader();
+    applyDefokoLogo();
+}
+
+// 10000分の1の確率でヘッダーロゴをデフォ子に変更
+function applyDefokoLogo() {
+    if (Math.random() < 1 / 10000) {
+        var img = document.getElementById('header-logo-img');
+        if (!img) return;
+        img.src = baseURL() + "/static/subekashi/image/defoko20260205.gif";
+        img.alt = "デフォ子";
+        img.style.height = "60px";
+        img.removeAttribute('width');
+    }
 }

--- a/subekashi/templates/subekashi/base/header.html
+++ b/subekashi/templates/subekashi/base/header.html
@@ -12,16 +12,9 @@
 
     <div id="subekashi-header">
         <div id="subekashi-header-top">
-            {% now "Y-m-d" as today %}
-            {% if today == "2026-02-05" %}
-                <a href="{% url 'article:default_article' 'dekoko202602' %}">
-                    <img name="thumbnail" src="{% static 'subekashi/image/defoko20260205.gif' %}" alt="デフォ子誕生祭2026年2月5日" style="height:60px" loading="lazy">
-                </a>
-            {% else %}
-                <a href="{% url 'subekashi:top' %}">
-                    <img name="thumbnail" src="{% static 'subekashi/image/icon.png' %}" alt="全て歌詞の所為です。のロゴ" height="45" width="45" loading="lazy">
-                </a>
-            {% endif %}
+            <a href="{% url 'subekashi:top' %}" id="header-logo-link">
+                <img name="thumbnail" id="header-logo-img" src="{% static 'subekashi/image/icon.png' %}" alt="全て歌詞の所為です。のロゴ" height="45" width="45" loading="lazy">
+            </a>
             {% if is_maintenance %}
                 <a href="{% url 'subekashi:top' %}">メンテナンス中です。</a>
             {% else %}


### PR DESCRIPTION
## Summary
- `header.html` のデフォ子ロゴ表示ロジックを日付条件（2026-02-05）から削除
- `base.js` に `applyDefokoLogo()` 関数を追加し、10000分の1の確率でデフォ子GIFに差し替えるよう実装
- インラインスクリプトを廃止し、`window.onload` から呼び出す形に整理

## Test plan
- [ ] 通常アクセスでは `icon.png` が表示されること
- [ ] `Math.random()` を一時的に `1` に変えてデフォ子GIFが正しく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)