### PR TITLE
[imitate DB] Phase 1b: imitate CharFieldからimitates ManyToManyFieldへのデータ移植コマンドを追加

### DIFF
--- a/subekashi/management/commands/migrate_imitates.py
+++ b/subekashi/management/commands/migrate_imitates.py
@@ -1,0 +1,64 @@
+from django.core.management.base import BaseCommand
+from subekashi.models import Song
+
+
+class Command(BaseCommand):
+    help = "imitate CharField から imitates ManyToManyField にデータを移植する"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--dry-run',
+            action='store_true',
+            help='実際には保存せず、移植内容をログ出力のみ行う',
+        )
+
+    def handle(self, *args, **options):
+        dry_run = options['dry_run']
+        if dry_run:
+            self.stdout.write(self.style.WARNING("=== DRY RUN モード（保存は行いません）==="))
+
+        total = 0
+        skipped = 0
+
+        for song in Song.objects.all():
+            if not song.imitate:
+                continue
+
+            ids = []
+            for raw in song.imitate.split(","):
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    ids.append(int(raw))
+                except ValueError:
+                    self.stdout.write(self.style.WARNING(
+                        f"  [{song.id}] 不正な値をスキップ: '{raw}'"
+                    ))
+
+            if not ids:
+                continue
+
+            targets = []
+            for target_id in ids:
+                try:
+                    targets.append(Song.objects.get(pk=target_id))
+                except Song.DoesNotExist:
+                    self.stdout.write(self.style.WARNING(
+                        f"  [{song.id}] 存在しないsong_idをスキップ: {target_id}"
+                    ))
+                    skipped += 1
+
+            if not targets:
+                continue
+
+            if not dry_run:
+                song.imitates.set(targets)
+
+            total += 1
+            if total % 100 == 0:
+                self.stdout.write(f"{total}件の模倣関係を処理しました")
+
+        self.stdout.write(self.style.SUCCESS(
+            f"\n完了: {total}件移植, {skipped}件スキップ"
+        ))


### PR DESCRIPTION
closes #836
親issue: #151

## Summary
- `subekashi/management/commands/migrate_imitates.py` を新規作成
- `imitate` CharField（カンマ区切りのsong id）を解析し `imitates` ManyToManyField に移植する
- `--dry-run` オプション対応（保存せずに移植内容をログ出力のみ）
- 存在しないsong idや不正な値はスキップしてログ出力
- 100件ごとに処理件数をログ出力
- 冪等動作（`imitates.set()` を使用するため重複実行しても結果が変わらない）

## 使い方
```sh
# 内容確認（保存なし）
python manage.py migrate_imitates --dry-run

# 実際に移植
python manage.py migrate_imitates
```

## Test plan
- [ ] `--dry-run` で移植予定の内容が正しくログ出力されること
- [ ] 実行後、`song.imitates.all()` が旧 `song.imitate` と同じ内容になっていること
- [ ] 存在しないsong idが `imitate` に含まれる場合、スキップされること
- [ ] 2回実行しても件数・内容が変わらないこと（冪等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)