### PR TITLE
[imitate DB] Phase 4: フロントエンドをimitates ManyToMany対応に更新

### DIFF
--- a/subekashi/static/subekashi/js/base.js
+++ b/subekashi/static/subekashi/js/base.js
@@ -425,7 +425,7 @@ function isLack(song) {
         ? song.authors.some(author => author.id === 1)
         : false;
 
-    if (!song.isoriginal && !song.issubeana && song.imitate === "" && hasSpecialAuthor) {
+    if (!song.isoriginal && !song.issubeana && song.imitates.length === 0 && hasSpecialAuthor) {
         return true;
     }
 

--- a/subekashi/templates/subekashi/song_edit.html
+++ b/subekashi/templates/subekashi/song_edit.html
@@ -77,7 +77,7 @@
                 </div>
             </template>
             <div id="imitate-list"></div>
-            <input type="text" id="imitate" name="imitate" value="{{ song.imitate }}" hidden>
+            <input type="text" id="imitate" name="imitate" value="{% for s in song.imitates.all %}{{ s.id }}{% if not forloop.last %},{% endif %}{% endfor %}" hidden>
         </div>
         <div class="form-col">
             <label for="lyrics">歌詞<i class="fas fa-info-circle" onclick="showTutorial('lyrics')"></i></label>


### PR DESCRIPTION
closes #832
親issue: #151

## Summary

### song_edit.html
- 模倣元の隠しinputの初期値を `song.imitate`（削除済み CharField）から `song.imitates.all` のID列に変更
  ```html
  <!-- before -->
  value="{{ song.imitate }}"
  <!-- after -->
  value="{% for s in song.imitates.all %}{{ s.id }}{% if not forloop.last %},{% endif %}{% endfor %}"
  ```

### base.js
- `isLack()` 内の模倣チェック条件を `song.imitate === ""` → `song.imitates.length === 0` に変更（APIレスポンスの型変更に対応）

## 変更不要だったファイル
- `song.html`: Phase 3で `song.py` が `imitate_list`/`imitated_list` を QuerySet で渡すように変更済みのためテンプレート側の変更は不要
- `songs.html`: `imitate` フィルターパラメータ名は変わらないため変更不要
- `songs.js`: API の `imitate` クエリパラメータを送る処理はそのまま動作するため変更不要
- `song_edit.js`: 隠しinputの読み書き処理はそのまま動作するため変更不要

## Test plan
- [ ] 模倣元が設定されている曲の編集画面で、既存の模倣元が正しく表示されること
- [ ] 模倣元を追加・削除して保存後、正しく反映されること
- [ ] `isLack` の判定が正しく動作すること（imitatesなし・subeana・非originalの曲が「作成途中」になること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)