### PR TITLE
[Fix] 異常に高いヘッダーのz-indexを下げ、トーストに干渉しないように

### DIFF
--- a/subekashi/static/subekashi/css/common.css
+++ b/subekashi/static/subekashi/css/common.css
@@ -39,7 +39,7 @@ body {
 
 /* ヘッダー */
 header {
-    z-index: 9999;
+    z-index: 1000;
     height: auto;
     width: 100%;
     background-color: #000;


### PR DESCRIPTION
ヘッダーのz-indexを下げ、トーストを覆わない様にします。
https://github.com/izumin2000/subekashi/issues/877 の対応です。