### PR TITLE
fix: auto YouTube フィルター適用時に distinct を追加し重複曲を排除

### DIFF
--- a/subekashi/lib/song_filterset.py
+++ b/subekashi/lib/song_filterset.py
@@ -216,7 +216,8 @@ class SongFilter(django_filters.FilterSet):
         has_youtube_filter = any(key in self.data for key in youtube_filters)
 
         # YouTube関連だがmediatypesが指定されていない場合、YouTubeフィルタを追加
-        if (has_youtube_sort or has_youtube_filter) and 'mediatypes' not in self.data:
+        auto_youtube_applied = (has_youtube_sort or has_youtube_filter) and 'mediatypes' not in self.data
+        if auto_youtube_applied:
             queryset = queryset.filter(filter_by_mediatypes('youtube'))
 
         # view関連のフィルタまたはソートがある場合、view >= 1 を適用
@@ -228,9 +229,10 @@ class SongFilter(django_filters.FilterSet):
             queryset = queryset.filter(like__gte=1)
 
         # フィルタ使用時、またはrandom/authorソート時にdistinct()を適用
+        # auto_youtube_applied の場合も links JOIN による重複が発生するため distinct が必要
         NEED_DISTINCT_KEY_LIST = ['author', 'author_exact', 'keyword', 'guesser', 'is_lack', 'url', 'mediatypes', 'imitate', 'imitated']
         NEED_DISTINCT_SORT_LIST = ['random', 'author', '-author']
-        if any(key in self.data for key in NEED_DISTINCT_KEY_LIST) or (self.data.get('sort') in NEED_DISTINCT_SORT_LIST):
+        if any(key in self.data for key in NEED_DISTINCT_KEY_LIST) or (self.data.get('sort') in NEED_DISTINCT_SORT_LIST) or auto_youtube_applied:
             ids = queryset.values('id').distinct()
             # Song.objects.filter(...) で新規 queryset を作るため、song_search.py で設定した
             # prefetch_related は引き継がれない。ここで明示的に再設定する。

--- a/subekashi/tests/test_lib_song_search.py
+++ b/subekashi/tests/test_lib_song_search.py
@@ -228,3 +228,37 @@ class SongSearchValidationErrorTest(TestCase):
     def test_title_too_long_raises_validation_error(self):
         with self.assertRaises(ValidationError):
             song_search({"title": "あ" * 501})
+
+
+class SongSearchAutoYoutubeFilterDuplicateTest(TestCase):
+    """auto YouTube フィルター適用時に複数リンクを持つ曲が重複しないことを検証"""
+
+    def setUp(self):
+        from datetime import datetime, timezone
+        self.song_a = Song.objects.create(
+            title="YouTube曲A（リンク2本）",
+            upload_time=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+        self.song_b = Song.objects.create(
+            title="YouTube曲B（リンク1本）",
+            upload_time=datetime(2024, 1, 2, tzinfo=timezone.utc),
+        )
+        # song_a に YouTube リンクを2本追加（重複の原因となるケース）
+        link1 = SongLink.objects.create(url="https://youtu.be/aaa111")
+        link1.songs.add(self.song_a)
+        link2 = SongLink.objects.create(url="https://youtu.be/aaa222")
+        link2.songs.add(self.song_a)
+        # song_b に YouTube リンクを1本追加
+        link3 = SongLink.objects.create(url="https://youtu.be/bbb111")
+        link3.songs.add(self.song_b)
+
+    def test_sort_upload_time_no_duplicate(self):
+        """sort=upload_time のみ指定時、複数 YouTube リンクを持つ曲が重複しない"""
+        _, stats = song_search({"sort": "upload_time", "size": "100"})
+        self.assertEqual(stats["count"], 2)
+
+    def test_sort_upload_time_same_count_as_explicit_mediatypes(self):
+        """sort=upload_time と sort=upload_time&mediatypes=youtube の件数が一致する"""
+        _, stats_auto = song_search({"sort": "upload_time", "size": "100"})
+        _, stats_explicit = song_search({"sort": "upload_time", "mediatypes": "youtube", "size": "100"})
+        self.assertEqual(stats_auto["count"], stats_explicit["count"])

--- a/subekashi/tests/test_lib_song_search.py
+++ b/subekashi/tests/test_lib_song_search.py
@@ -4,6 +4,7 @@ lib/song_search.py のテスト
 song_search() のページネーション・統計情報・バリデーションエラー処理を検証する。
 """
 import math
+from datetime import datetime, timezone
 from django.test import TestCase
 from rest_framework.exceptions import ValidationError
 from subekashi.models import Author, Song, SongLink
@@ -234,14 +235,15 @@ class SongSearchAutoYoutubeFilterDuplicateTest(TestCase):
     """auto YouTube フィルター適用時に複数リンクを持つ曲が重複しないことを検証"""
 
     def setUp(self):
-        from datetime import datetime, timezone
         self.song_a = Song.objects.create(
             title="YouTube曲A（リンク2本）",
             upload_time=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            view=100,
         )
         self.song_b = Song.objects.create(
             title="YouTube曲B（リンク1本）",
             upload_time=datetime(2024, 1, 2, tzinfo=timezone.utc),
+            view=200,
         )
         # song_a に YouTube リンクを2本追加（重複の原因となるケース）
         link1 = SongLink.objects.create(url="https://youtu.be/aaa111")
@@ -252,13 +254,30 @@ class SongSearchAutoYoutubeFilterDuplicateTest(TestCase):
         link3 = SongLink.objects.create(url="https://youtu.be/bbb111")
         link3.songs.add(self.song_b)
 
-    def test_sort_upload_time_no_duplicate(self):
-        """sort=upload_time のみ指定時、複数 YouTube リンクを持つ曲が重複しない"""
-        _, stats = song_search({"sort": "upload_time", "size": "100"})
+    def _assert_no_duplicate(self, params):
+        """返ってきた曲に重複がなく、期待する2曲が含まれることを検証するヘルパー"""
+        songs, stats = song_search({**params, "size": "100"})
+        song_ids = [s.id for s in songs]
         self.assertEqual(stats["count"], 2)
+        self.assertEqual(len(song_ids), 2)
+        self.assertEqual(len(set(song_ids)), 2)
+        self.assertIn(self.song_a.id, song_ids)
+        self.assertIn(self.song_b.id, song_ids)
+
+    def test_sort_upload_time_no_duplicate(self):
+        """has_youtube_sort パス: sort=upload_time のみ指定時に重複しない"""
+        self._assert_no_duplicate({"sort": "upload_time"})
 
     def test_sort_upload_time_same_count_as_explicit_mediatypes(self):
         """sort=upload_time と sort=upload_time&mediatypes=youtube の件数が一致する"""
         _, stats_auto = song_search({"sort": "upload_time", "size": "100"})
         _, stats_explicit = song_search({"sort": "upload_time", "mediatypes": "youtube", "size": "100"})
         self.assertEqual(stats_auto["count"], stats_explicit["count"])
+
+    def test_upload_time_gte_filter_no_duplicate(self):
+        """has_youtube_filter パス: upload_time_gte 指定時に重複しない"""
+        self._assert_no_duplicate({"upload_time_gte": "2024-01-01T00:00:00Z"})
+
+    def test_view_lte_filter_no_duplicate(self):
+        """has_youtube_filter パス: view_lte 指定時に重複しない"""
+        self._assert_no_duplicate({"view_lte": "500"})

--- a/subekashi/tests/test_lib_song_search.py
+++ b/subekashi/tests/test_lib_song_search.py
@@ -272,6 +272,7 @@ class SongSearchAutoYoutubeFilterDuplicateTest(TestCase):
         """sort=upload_time と sort=upload_time&mediatypes=youtube の件数が一致する"""
         _, stats_auto = song_search({"sort": "upload_time", "size": "100"})
         _, stats_explicit = song_search({"sort": "upload_time", "mediatypes": "youtube", "size": "100"})
+        self.assertEqual(stats_auto["count"], 2)
         self.assertEqual(stats_auto["count"], stats_explicit["count"])
 
     def test_upload_time_gte_filter_no_duplicate(self):


### PR DESCRIPTION
## 概要

`sort=upload_time` など YouTube 関連ソートを指定した際、`mediatypes` を明示しない場合に自動で YouTube フィルターが適用されますが、この際 `links__url__regex` の JOIN による重複排除が行われておらず、複数の YouTube リンクを持つ曲が重複して返されるバグがありました。

## 原因

[song_filterset.py](subekashi/lib/song_filterset.py) の `qs` プロパティにて、自動 YouTube フィルター適用パスでは `distinct()` が適用されていませんでした。

- `mediatypes=youtube` を明示した場合 → `NEED_DISTINCT_KEY_LIST` に該当 → **distinct あり**
- 自動適用の場合（`sort=upload_time` のみ） → distinct チェックをスルー → **distinct なし** ← バグ

## 修正内容

`auto_youtube_applied` フラグを導入し、distinct チェックの条件に追加することで、自動適用時も `mediatypes` 明示時と同じサブクエリベースの distinct が適用されるようにしました。

## テスト

`SongSearchAutoYoutubeFilterDuplicateTest` を追加:
- 複数 YouTube リンクを持つ曲が `sort=upload_time` で重複して返らないことを確認
- `sort=upload_time` と `sort=upload_time&mediatypes=youtube` の件数が一致することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)