### PR TITLE
feat: トーストに✕ボタンを追加

### DIFF
--- a/subekashi/static/subekashi/css/common.css
+++ b/subekashi/static/subekashi/css/common.css
@@ -1026,6 +1026,29 @@ input::placeholder {
     line-height: normal;
 }
 
+.toast-close {
+    position: absolute;
+    top: 6px;
+    right: 8px;
+    background: none;
+    border: none;
+    font-size: 22px;
+    line-height: 1;
+    color: #555;
+    cursor: pointer;
+    padding: 0;
+    margin: 0;
+    width: auto;
+    height: auto;
+    border-radius: 0;
+    transition: color 0.15s;
+}
+
+.toast-close:hover {
+    background: none;
+    color: #111;
+}
+
 .toast a {
     text-decoration: underline 2px #111;
 }

--- a/subekashi/static/subekashi/js/base.js
+++ b/subekashi/static/subekashi/js/base.js
@@ -136,10 +136,16 @@ async function showToast(icon, text) {
     // 50文字越えの場合はlong用に
     if(text.length > 50) toastDiv.classList.add("long-time");
     iconI.className = icons[icon] ?? "";
+    const closeBtn = document.createElement("button");
+    closeBtn.className = "toast-close";
+    closeBtn.textContent = "✕";
+    closeBtn.addEventListener("click", () => toastDiv.remove());
+
     //組み立て
     contentP.appendChild(iconI);
     contentP.innerHTML += text;
     toastDiv.appendChild(contentP);
+    toastDiv.appendChild(closeBtn);
 
     const toastContainerEle = document.getElementById('toast-container');
     if(!toastContainerEle) {


### PR DESCRIPTION
## Summary
- `showToast` でトーストに `<button class="toast-close">✕</button>` を追加
- クリック時に `toastDiv.remove()` でトーストを即座に閉じる
- `.toast-close` のスタイルをグローバル `button` スタイルの影響を受けないよう上書き

## Test plan
- [ ] トーストが表示された際に右上に✕ボタンが表示されることを確認
- [ ] ✕ボタンをクリックするとトーストが即座に閉じることを確認
- [ ] 通常のタイムアウトによる自動消去が引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)