### PR TITLE
feat: 投稿日順ソート時にYouTubeフィルタのsearch-infoを表示する

### DIFF
--- a/subekashi/lib/query_utils.py
+++ b/subekashi/lib/query_utils.py
@@ -53,3 +53,16 @@ def has_like_filter_or_sort(query_data):
     has_like_lte_filter = 'like_lte' in query_data
     has_like_sort = query_data.get('sort') in ['like', '-like']
     return has_like_lte_filter or has_like_sort
+
+
+def has_upload_time_sort(query_data):
+    """
+    upload_time関連のソートが存在するかチェック
+
+    Args:
+        query_data: クエリパラメータの辞書
+
+    Returns:
+        bool: upload_time関連のソートが存在する場合True
+    """
+    return query_data.get('sort') in ['upload_time', '-upload_time']

--- a/subekashi/lib/song_filterset.py
+++ b/subekashi/lib/song_filterset.py
@@ -11,7 +11,7 @@ from subekashi.lib.query_filters import (
     filter_by_lack,
 )
 from subekashi.lib.url import clean_url
-from subekashi.lib.query_utils import has_view_filter_or_sort, has_like_filter_or_sort
+from subekashi.lib.query_utils import has_view_filter_or_sort, has_like_filter_or_sort, has_upload_time_sort
 
 # URLパラメータのソートフィールド名 → Django ORM のフィールド名マッピング
 AUTHOR_SORT_MAP = {'author': 'authors__name', '-author': '-authors__name'}
@@ -207,7 +207,7 @@ class SongFilter(django_filters.FilterSet):
 
         # YouTube関連のパラメータが存在するかチェック
         YOUTUBE_ITEMS = ['view', 'like', 'upload_time']
-        YOUTUBE_SORT = ['upload_time', '-upload_time', 'view', '-view', 'like', '-like']
+        YOUTUBE_SORT = ['view', '-view', 'like', '-like']
 
         youtube_filters = [f'{item}_gte' for item in YOUTUBE_ITEMS] + \
                           [f'{item}_lte' for item in YOUTUBE_ITEMS]
@@ -220,6 +220,11 @@ class SongFilter(django_filters.FilterSet):
         if auto_youtube_applied:
             queryset = queryset.filter(filter_by_mediatypes('youtube'))
 
+        # upload_timeソートがある場合、mediatypes=youtubeを明示的に適用
+        upload_time_youtube_applied = has_upload_time_sort(self.data) and 'mediatypes' not in self.data
+        if upload_time_youtube_applied:
+            queryset = queryset.filter(filter_by_mediatypes('youtube'))
+
         # view関連のフィルタまたはソートがある場合、view >= 1 を適用
         if has_view_filter_or_sort(self.data):
             queryset = queryset.filter(view__gte=1)
@@ -229,10 +234,10 @@ class SongFilter(django_filters.FilterSet):
             queryset = queryset.filter(like__gte=1)
 
         # フィルタ使用時、またはrandom/authorソート時にdistinct()を適用
-        # auto_youtube_applied の場合も links JOIN による重複が発生するため distinct が必要
+        # auto_youtube_applied / upload_time_youtube_applied の場合も links JOIN による重複が発生するため distinct が必要
         NEED_DISTINCT_KEY_LIST = ['author', 'author_exact', 'keyword', 'guesser', 'is_lack', 'url', 'mediatypes', 'imitate', 'imitated']
         NEED_DISTINCT_SORT_LIST = ['random', 'author', '-author']
-        if any(key in self.data for key in NEED_DISTINCT_KEY_LIST) or (self.data.get('sort') in NEED_DISTINCT_SORT_LIST) or auto_youtube_applied:
+        if any(key in self.data for key in NEED_DISTINCT_KEY_LIST) or (self.data.get('sort') in NEED_DISTINCT_SORT_LIST) or auto_youtube_applied or upload_time_youtube_applied:
             ids = queryset.values('id').distinct()
             # Song.objects.filter(...) で新規 queryset を作るため、song_search.py で設定した
             # prefetch_related は引き継がれない。ここで明示的に再設定する。

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -357,8 +357,8 @@
 
 | テストケース | 条件 | 期待結果 |
 | --- | --- | --- |
-| `sort=upload_time` | GETリクエスト | HTTP 200、「再生数が1回以上の曲を表示しています」が含まれる |
-| `sort=-upload_time` | GETリクエスト | HTTP 200、「再生数が1回以上の曲を表示しています」が含まれる |
+| `sort=upload_time` | GETリクエスト | HTTP 200、「YouTubeの曲を表示しています」が含まれる |
+| `sort=-upload_time` | GETリクエスト | HTTP 200、「YouTubeの曲を表示しています」が含まれる |
 | ソート指定なし | GETリクエスト | 投稿日用のsearch-infoが含まれない |
 | `sort=title` | GETリクエスト | 投稿日用のsearch-infoが含まれない |
 

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -203,6 +203,17 @@
 | `sort=-like` | `{"sort": "-like"}` | `True` |
 | 空辞書 | `{}` | `False` |
 
+#### 4-4. `has_upload_time_sort(query_data)`
+
+| テストケース | 入力 | 期待結果 |
+| --- | --- | --- |
+| `sort=upload_time` | `{"sort": "upload_time"}` | `True` |
+| `sort=-upload_time` | `{"sort": "-upload_time"}` | `True` |
+| 別のソート | `{"sort": "title"}` | `False` |
+| 空辞書 | `{}` | `False` |
+| view系ソート | `{"sort": "view"}` | `False` |
+| like系ソート | `{"sort": "like"}` | `False` |
+
 ---
 
 ### 5. `lib/author_helpers.py` — 作者ヘルパー
@@ -341,6 +352,15 @@
 | テストケース | 条件 | 期待結果 |
 | --- | --- | --- |
 | 正常アクセス | GETリクエスト | HTTP 200 |
+
+#### 7-11. `SongCardsView` (`/api/html/song_cards`)
+
+| テストケース | 条件 | 期待結果 |
+| --- | --- | --- |
+| `sort=upload_time` | GETリクエスト | HTTP 200、「再生数が1回以上の曲を表示しています」が含まれる |
+| `sort=-upload_time` | GETリクエスト | HTTP 200、「再生数が1回以上の曲を表示しています」が含まれる |
+| ソート指定なし | GETリクエスト | 投稿日用のsearch-infoが含まれない |
+| `sort=title` | GETリクエスト | 投稿日用のsearch-infoが含まれない |
 
 ---
 

--- a/subekashi/tests/test_lib_query_utils.py
+++ b/subekashi/tests/test_lib_query_utils.py
@@ -9,6 +9,7 @@ from subekashi.lib.query_utils import (
     clean_query_params,
     has_view_filter_or_sort,
     has_like_filter_or_sort,
+    has_upload_time_sort,
 )
 
 
@@ -101,3 +102,25 @@ class HasLikeFilterOrSortTest(SimpleTestCase):
 
     def test_like_lte_combined_with_other_keys(self):
         self.assertTrue(has_like_filter_or_sort({"like_lte": "10", "sort": "id"}))
+
+
+class HasUploadTimeSortTest(SimpleTestCase):
+    """has_upload_time_sort() のテスト"""
+
+    def test_sort_upload_time_returns_true(self):
+        self.assertTrue(has_upload_time_sort({"sort": "upload_time"}))
+
+    def test_sort_minus_upload_time_returns_true(self):
+        self.assertTrue(has_upload_time_sort({"sort": "-upload_time"}))
+
+    def test_other_sort_returns_false(self):
+        self.assertFalse(has_upload_time_sort({"sort": "title"}))
+
+    def test_empty_dict_returns_false(self):
+        self.assertFalse(has_upload_time_sort({}))
+
+    def test_view_sort_returns_false(self):
+        self.assertFalse(has_upload_time_sort({"sort": "view"}))
+
+    def test_like_sort_returns_false(self):
+        self.assertFalse(has_upload_time_sort({"sort": "like"}))

--- a/subekashi/tests/test_views.py
+++ b/subekashi/tests/test_views.py
@@ -343,29 +343,29 @@ class SongCardsViewTest(TestCase):
         Song.objects.create(title="カードテスト曲", lyrics="歌詞")
 
     def test_sort_upload_time_shows_search_info(self):
-        """sort=upload_time のとき「再生数が1回以上の曲を表示しています」が含まれること"""
+        """sort=upload_time のとき「YouTubeの曲を表示しています」が含まれること"""
         response = self.client.get(
             reverse("subekashi:song_cards"), {"sort": "upload_time"}
         )
         self.assertEqual(response.status_code, 200)
         content = "".join(response.json())
-        self.assertIn("再生数が1回以上の曲を表示しています", content)
+        self.assertIn("YouTubeの曲を表示しています", content)
 
     def test_sort_minus_upload_time_shows_search_info(self):
-        """sort=-upload_time のとき「再生数が1回以上の曲を表示しています」が含まれること"""
+        """sort=-upload_time のとき「YouTubeの曲を表示しています」が含まれること"""
         response = self.client.get(
             reverse("subekashi:song_cards"), {"sort": "-upload_time"}
         )
         self.assertEqual(response.status_code, 200)
         content = "".join(response.json())
-        self.assertIn("再生数が1回以上の曲を表示しています", content)
+        self.assertIn("YouTubeの曲を表示しています", content)
 
     def test_no_sort_does_not_show_upload_time_search_info(self):
         """sort指定なしのとき投稿日用のsearch-infoが含まれないこと"""
         response = self.client.get(reverse("subekashi:song_cards"))
         self.assertEqual(response.status_code, 200)
         content = "".join(response.json())
-        self.assertNotIn("再生数が1回以上の曲を表示しています", content)
+        self.assertNotIn("YouTubeの曲を表示しています", content)
 
     def test_other_sort_does_not_show_upload_time_search_info(self):
         """sort=title のとき投稿日用のsearch-infoが含まれないこと"""
@@ -374,7 +374,7 @@ class SongCardsViewTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         content = "".join(response.json())
-        self.assertNotIn("再生数が1回以上の曲を表示しています", content)
+        self.assertNotIn("YouTubeの曲を表示しています", content)
 
 
 @override_settings(STATICFILES_STORAGE=STATIC_STORAGE)

--- a/subekashi/tests/test_views.py
+++ b/subekashi/tests/test_views.py
@@ -334,6 +334,49 @@ class HistoriesViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
 
 
+@override_settings(STATICFILES_STORAGE=STATIC_STORAGE, RATELIMIT_ENABLE=False)
+class SongCardsViewTest(TestCase):
+    """SongCardsView (/api/html/song_cards) のテスト"""
+
+    def setUp(self):
+        self.client = Client()
+        Song.objects.create(title="カードテスト曲", lyrics="歌詞")
+
+    def test_sort_upload_time_shows_search_info(self):
+        """sort=upload_time のとき「再生数が1回以上の曲を表示しています」が含まれること"""
+        response = self.client.get(
+            reverse("subekashi:song_cards"), {"sort": "upload_time"}
+        )
+        self.assertEqual(response.status_code, 200)
+        content = "".join(response.json())
+        self.assertIn("再生数が1回以上の曲を表示しています", content)
+
+    def test_sort_minus_upload_time_shows_search_info(self):
+        """sort=-upload_time のとき「再生数が1回以上の曲を表示しています」が含まれること"""
+        response = self.client.get(
+            reverse("subekashi:song_cards"), {"sort": "-upload_time"}
+        )
+        self.assertEqual(response.status_code, 200)
+        content = "".join(response.json())
+        self.assertIn("再生数が1回以上の曲を表示しています", content)
+
+    def test_no_sort_does_not_show_upload_time_search_info(self):
+        """sort指定なしのとき投稿日用のsearch-infoが含まれないこと"""
+        response = self.client.get(reverse("subekashi:song_cards"))
+        self.assertEqual(response.status_code, 200)
+        content = "".join(response.json())
+        self.assertNotIn("再生数が1回以上の曲を表示しています", content)
+
+    def test_other_sort_does_not_show_upload_time_search_info(self):
+        """sort=title のとき投稿日用のsearch-infoが含まれないこと"""
+        response = self.client.get(
+            reverse("subekashi:song_cards"), {"sort": "title"}
+        )
+        self.assertEqual(response.status_code, 200)
+        content = "".join(response.json())
+        self.assertNotIn("再生数が1回以上の曲を表示しています", content)
+
+
 @override_settings(STATICFILES_STORAGE=STATIC_STORAGE)
 class RedirectViewTest(TestCase):
     """/search/ と /new/ のリダイレクトテスト"""

--- a/subekashi/views/components/song_cards.py
+++ b/subekashi/views/components/song_cards.py
@@ -88,7 +88,7 @@ def song_cards(request):
 
         # 投稿日のソートなら.search-infoを追加
         if has_upload_time_sort(cleaned_query):
-            result.append("<p class='search-info'>再生数が1回以上の曲を表示しています</p>")
+            result.append("<p class='search-info'>YouTubeの曲を表示しています</p>")
         
         # ヒット数以外の何かしらの検索情報があれば水平線を画面に表示する
         if result:

--- a/subekashi/views/components/song_cards.py
+++ b/subekashi/views/components/song_cards.py
@@ -6,6 +6,7 @@ from subekashi.lib.query_utils import (
     clean_query_params,
     has_view_filter_or_sort,
     has_like_filter_or_sort,
+    has_upload_time_sort,
 )
 from django_ratelimit.decorators import ratelimit
 from rest_framework.exceptions import ValidationError
@@ -84,6 +85,10 @@ def song_cards(request):
         # 高評価数のフィルター/ソートなら.search-infoを追加
         if has_like_filter_or_sort(cleaned_query):
             result.append("<p class='search-info'>高評価数が1以上の曲を表示しています</p>")
+
+        # 投稿日のソートなら.search-infoを追加
+        if has_upload_time_sort(cleaned_query):
+            result.append("<p class='search-info'>再生数が1回以上の曲を表示しています</p>")
         
         # ヒット数以外の何かしらの検索情報があれば水平線を画面に表示する
         if result:


### PR DESCRIPTION
## Summary

- `sort=upload_time` / `sort=-upload_time` のとき、`song_filterset.py` で `has_upload_time_sort` + `filter_by_mediatypes('youtube')` を明示的に適用するよう変更（`YOUTUBE_SORT` の汎用処理から切り出し）
- `song_cards.py` に `<p class='search-info'>YouTubeの曲を表示しています</p>` を追加
- `query_utils.py` に `has_upload_time_sort()` 関数を追加
- 対応するテスト (`HasUploadTimeSortTest`・`SongCardsViewTest`) およびテスト計画書を追加

## Test plan

- [ ] `python manage.py test subekashi.tests` が全件パスすること
- [ ] `sort=upload_time` で曲一覧を表示し、「YouTubeの曲を表示しています」が出ることを確認
- [ ] `sort=-upload_time` で同様に確認
- [ ] ソート指定なし・`sort=title` ではsearch-infoが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)