### PR TITLE
[Fix] mediatypes=otherのURL未登録検索がヒットしない不具合の修正

### DIFF
--- a/subekashi/lib/query_filters.py
+++ b/subekashi/lib/query_filters.py
@@ -31,16 +31,24 @@ def filter_by_guesser(guesser):
 # メディアの検索に利用するフィルター
 def filter_by_mediatypes(mediatypes):
     # mediatypeに当てはまる正規表現を抜き出す
+    # "other"（URL未登録）はリンクが1件も存在しないことを示すため、
+    # links__url__regex では判定できず個別にExistsで判定する
     media_regex_list = []
+    query = Q()
     for mediatype in mediatypes.split(","):
+        if mediatype == "other":
+            # 非公開/削除済みの曲は対象外とする
+            any_links = SongLink.objects.filter(songs=OuterRef('pk'))
+            query |= Q(is_deleted=False) & ~Exists(any_links)
+            continue
         for i, media in enumerate(ALL_MEDIAS):
             if mediatype == media["id"]:
                 media_regex_list.append(f"({ALL_MEDIAS[i]['regex']})")
                 continue
-    media_regex = "|".join(media_regex_list)
-    return (
-        Q(links__url__regex=media_regex)
-    )
+    if media_regex_list:
+        media_regex = "|".join(media_regex_list)
+        query |= Q(links__url__regex=media_regex)
+    return query
 
 # 未完成フィルター
 def filter_by_lack():

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -162,7 +162,17 @@
 | 歌詞なし・インストではない曲 | `is_inst=False`, `lyrics=""` | 結果に含まれる |
 | すべて完備している曲 | URL・歌詞・作者あり | 結果に含まれない |
 
-#### 3-3. `make_is_lack_annotation()`
+#### 3-3. `filter_by_mediatypes(mediatypes)`
+
+| テストケース | 前提条件 | 期待結果 |
+| --- | --- | --- |
+| `other`（URL未登録） | SongLink が1件も紐付いていない曲 | 結果に含まれる |
+| `other`（URL未登録） | SongLink が紐付いている曲 | 結果に含まれない |
+| `other`（URL未登録） | SongLink なし かつ `is_deleted=True`（非公開/削除済み） | 結果に含まれない |
+| 個別メディアタイプ（例: `youtube`） | 該当URLのSongLinkが紐付いている曲 | 結果に含まれる。URLなしの曲は含まれない |
+| 複数指定（例: `youtube,other`） | URLありの曲・URLなしの曲がそれぞれ存在 | 両方とも結果に含まれる |
+
+#### 3-4. `make_is_lack_annotation()`
 
 | テストケース | 前提条件 | 期待結果 |
 | --- | --- | --- |

--- a/subekashi/tests/test_lib_query_filters.py
+++ b/subekashi/tests/test_lib_query_filters.py
@@ -11,6 +11,7 @@ from subekashi.lib.query_filters import (
     filter_by_imitated,
     filter_by_guesser,
     filter_by_lack,
+    filter_by_mediatypes,
     make_is_lack_annotation,
 )
 
@@ -156,6 +157,44 @@ class FilterByLackTest(TestCase):
         # URL を持たないまま → 条件(A)は「is_deleted=False かつ URLなし」なので is_deleted=True は除外される
         qs = Song.objects.filter(filter_by_lack())
         self.assertNotIn(song, qs)
+
+
+class FilterByMediatypesTest(TestCase):
+    """filter_by_mediatypes() のテスト
+
+    "other"（URL未登録）はSongLinkが1件も存在しないことを表すため、
+    links__url__regex では判定できず ~Exists() で判定する必要がある。
+    また非公開/削除済み（is_deleted=True）の曲は対象外とする。
+    """
+
+    def setUp(self):
+        self.song_without_link = Song.objects.create(title="URL未登録曲")
+        self.deleted_song_without_link = Song.objects.create(title="削除済みURL未登録曲", is_deleted=True)
+        self.song_with_youtube_link = Song.objects.create(title="YouTube曲")
+        link = SongLink.objects.create(url="https://youtu.be/mediatype12345")
+        link.songs.add(self.song_with_youtube_link)
+
+    def test_other_matches_song_without_any_link(self):
+        qs = Song.objects.filter(filter_by_mediatypes("other")).distinct()
+        self.assertIn(self.song_without_link, qs)
+
+    def test_other_does_not_match_song_with_link(self):
+        qs = Song.objects.filter(filter_by_mediatypes("other")).distinct()
+        self.assertNotIn(self.song_with_youtube_link, qs)
+
+    def test_other_does_not_match_deleted_song(self):
+        qs = Song.objects.filter(filter_by_mediatypes("other")).distinct()
+        self.assertNotIn(self.deleted_song_without_link, qs)
+
+    def test_youtube_matches_song_with_youtube_link(self):
+        qs = Song.objects.filter(filter_by_mediatypes("youtube")).distinct()
+        self.assertIn(self.song_with_youtube_link, qs)
+        self.assertNotIn(self.song_without_link, qs)
+
+    def test_youtube_and_other_combined_matches_both(self):
+        qs = Song.objects.filter(filter_by_mediatypes("youtube,other")).distinct()
+        self.assertIn(self.song_with_youtube_link, qs)
+        self.assertIn(self.song_without_link, qs)
 
 
 class MakeIsLackAnnotationTest(TestCase):


### PR DESCRIPTION
## Summary
- `filter_by_mediatypes()` の `other`（URL未登録）判定を修正。`SongLink` はM2M関係かつ`url`が空文字になり得ないため、`links__url__regex="^$"` ではリンクが1件も無いSongを判定できず常に0件になっていた。`~Exists()` による判定に置き換え。
- 追加要件として、非公開/削除済み（`is_deleted=True`）の曲は `other` の対象外とした。

## Test plan
- [x] `subekashi/tests/test_lib_query_filters.py` に `FilterByMediatypesTest` を追加（other単体・リンクありとの区別・削除済み曲の除外・他タイプとの併用）
- [x] `python manage.py test subekashi.tests article.tests` で333件全て成功
- [x] `subekashi/tests/TEST_PLAN_UNIT.md` にテストケースを追記

Closes #958

🤖 Generated with [Claude Code](https://claude.com/claude-code)