### PR TITLE
[Add] is_questionableの実装

### DIFF
--- a/subekashi/forms.py
+++ b/subekashi/forms.py
@@ -47,3 +47,4 @@ class SongEditForm(forms.Form):
     is_inst = forms.BooleanField(required=False)
     is_subeana = forms.BooleanField(required=False)
     is_draft = forms.BooleanField(required=False)
+    is_questionable = forms.BooleanField(required=False)

--- a/subekashi/lib/query_filters.py
+++ b/subekashi/lib/query_filters.py
@@ -54,7 +54,7 @@ def filter_by_mediatypes(mediatypes):
 def filter_by_lack():
     any_links = SongLink.objects.filter(songs=OuterRef('pk'))
     has_author_1 = Author.objects.filter(id=1, songs__id=OuterRef('pk'))
-    return (
+    return Q(is_questionable=False) & (
         (Q(is_deleted=False) & ~Exists(any_links)) |
         (Q(is_original=False, is_subeana=True, imitates__isnull=True) & ~Exists(has_author_1)) |
         Q(is_inst=False, lyrics="")
@@ -66,6 +66,7 @@ def make_is_lack_annotation():
     any_links = SongLink.objects.filter(songs=OuterRef('pk'))
     has_author_1 = Author.objects.filter(id=1, songs__id=OuterRef('pk'))
     return Case(
+        When(Q(is_questionable=True), then=Value(False)),
         When(Q(is_deleted=False) & ~Exists(any_links), then=Value(True)),
         When(Q(is_original=False, is_subeana=True, imitates__isnull=True) & ~Exists(has_author_1), then=Value(True)),
         When(Q(is_inst=False, lyrics=''), then=Value(True)),

--- a/subekashi/lib/song_filterset.py
+++ b/subekashi/lib/song_filterset.py
@@ -107,6 +107,7 @@ class SongFilter(django_filters.FilterSet):
     is_inst = django_filters.BooleanFilter()
     is_deleted = django_filters.BooleanFilter()
     is_limited = django_filters.BooleanFilter()
+    is_questionable = django_filters.BooleanFilter()
 
     # カスタムフィルタ
     keyword = django_filters.CharFilter(

--- a/subekashi/lib/song_service.py
+++ b/subekashi/lib/song_service.py
@@ -41,6 +41,7 @@ def create_song(fields: SongFields):
         is_joke=fields.is_joke,
         is_inst=fields.is_inst,
         is_subeana=fields.is_subeana,
+        is_questionable=fields.is_questionable,
         upload_time=fields.upload_time,
         view=fields.view,
         like=fields.like,
@@ -89,6 +90,7 @@ def update_song(song, fields: SongFields, author_objects, imitate_songs, cleaned
         song.is_inst = fields.is_inst
         song.is_subeana = fields.is_subeana
         song.is_draft = fields.is_draft
+        song.is_questionable = fields.is_questionable
         song.post_time = timezone.now()
         song.save()
         song.imitates.set(imitate_songs)
@@ -142,6 +144,7 @@ def build_new_song_discord_text(song_id, fields: SongFields, authors, cleaned_ur
         {"label": "ネタ曲", "value": yes_no(fields.is_joke)},
         {"label": "インスト曲", "value": yes_no(fields.is_inst)},
         {"label": "すべあな模倣曲", "value": yes_no(fields.is_subeana)},
+        {"label": "界隈曲?", "value": yes_no(fields.is_questionable)},
     ]
 
     changes = [["種類", "内容"]]
@@ -173,6 +176,7 @@ def build_edit_song_discord_text(song_id, song, fields: SongFields, author_objec
         {"label": "インスト曲", "before": yes_no(song.is_inst), "after": yes_no(fields.is_inst)},
         {"label": "すべあな模倣曲", "before": yes_no(song.is_subeana), "after": yes_no(fields.is_subeana)},
         {"label": "下書き", "before": yes_no(song.is_draft), "after": yes_no(fields.is_draft)},
+        {"label": "界隈曲?", "before": yes_no(song.is_questionable), "after": yes_no(fields.is_questionable)},
         {"label": "模倣", "before": songs_to_info(old_imitate_songs), "after": songs_to_info(imitate_songs)},
         {"label": "歌詞", "before": song.lyrics, "after": fields.lyrics.replace("\r\n", "\n")},
     ]

--- a/subekashi/migrations/0036_song_is_questionable.py
+++ b/subekashi/migrations/0036_song_is_questionable.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('subekashi', '0035_rename_song_boolean_fields'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='song',
+            name='is_questionable',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/subekashi/migrations/0037_data_migrate_is_questionable.py
+++ b/subekashi/migrations/0037_data_migrate_is_questionable.py
@@ -1,0 +1,24 @@
+from django.db import migrations
+
+QUESTIONABLE_SONG_IDS = [6570, 7989, 8000, 8012, 8016]
+
+
+def set_is_questionable(apps, schema_editor):
+    Song = apps.get_model('subekashi', 'Song')
+    Song.objects.filter(id__in=QUESTIONABLE_SONG_IDS).update(is_questionable=True)
+
+
+def unset_is_questionable(apps, schema_editor):
+    Song = apps.get_model('subekashi', 'Song')
+    Song.objects.filter(id__in=QUESTIONABLE_SONG_IDS).update(is_questionable=False)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('subekashi', '0036_song_is_questionable'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_is_questionable, unset_is_questionable),
+    ]

--- a/subekashi/models/song.py
+++ b/subekashi/models/song.py
@@ -38,6 +38,7 @@ class Song(GetOrNoneMixin, models.Model):
     is_special = models.BooleanField(default = False)
     is_lock = models.BooleanField(default = False)
     is_limited = models.BooleanField(default = False)
+    is_questionable = models.BooleanField(default = False)
     view = models.IntegerField(blank = True, null = True)
     like = models.IntegerField(blank = True, null = True)
     category = models.CharField(default = "song", choices=CHOICES, max_length=10)
@@ -96,6 +97,7 @@ class SongFields:
     is_inst: bool = False
     is_subeana: bool = True
     is_draft: bool = False
+    is_questionable: bool = False
     upload_time: Optional[datetime] = None
     view: Optional[int] = None
     like: Optional[int] = None

--- a/subekashi/static/subekashi/js/base.js
+++ b/subekashi/static/subekashi/js/base.js
@@ -415,6 +415,10 @@ function getAuthorText(song) {
 
 // 曲が未完成かどうか
 function isLack(song) {
+    if (song.is_questionable) {
+        return false;
+    }
+
     if (!song.is_deleted && (!song.url || song.url.length === 0)) {
         return true;
     }

--- a/subekashi/static/subekashi/js/song_edit.js
+++ b/subekashi/static/subekashi/js/song_edit.js
@@ -23,6 +23,7 @@ async function init() {
     document.getElementById("song-guesser").innerHTML = "";
     checkButton();
     checkDeleteForm();
+    updateQuestionableVisibility();
 };
 window.addEventListener('load', init);
 
@@ -344,6 +345,16 @@ async function checkUrlForm(prefetchedLinks = undefined) {
 }
 urlEle.addEventListener('input', checkUrlForm);
 
+// 界隈曲?チェック時、曲名/作者/URL以外のフォームを非表示にする
+function updateQuestionableVisibility() {
+    const checked = document.getElementById('is-questionable').checked;
+    document.querySelectorAll('[data-hide-if-questionable]').forEach(el => {
+        el.style.display = checked ? 'none' : '';
+    });
+    checkButton();
+}
+document.getElementById('is-questionable').addEventListener('change', updateQuestionableVisibility);
+
 // 登録ボタン
 function checkButton() {
     // ボタンのdisabledの変更
@@ -353,25 +364,29 @@ function checkButton() {
     // 未完成に関する変数の定義
     var message = "";
     var is_lack = false;
-    
+    const isQuestionable = document.getElementById('is-questionable').checked;
+
     // URLの未完成
     if (!document.getElementById("is-deleted").checked && (urlEle.value == "")) {
         message += "<li>「非公開/削除済み」にチェックをつけるか、URLを入力してください。</li>"
         is_lack = true;
     }
-    
-    // 模倣の未完成
-    const is_original = document.getElementById("is-original").checked;
-    const is_subeana = document.getElementById("is-subeana").checked;
-    if (!is_original && is_subeana && (imitateEle.value == "") && (authorsEle.value != "全てあなたの所為です。")) {
-        message += "<li>「オリジナル模倣」にチェックをつけるか、模倣曲を1曲以上登録してください。</li>"
-        is_lack = true;
-    }
 
-    // 歌詞の未完成
-    if (!document.getElementById("is-inst").checked && (lyricsEle.value == "")) {
-        message += "<li>「インスト」にチェックをつけるか、歌詞を入力してください。</li>"
-        is_lack = true;
+    // 界隈曲?の場合、歌詞・模倣は非表示かつ強制的に空になるため未完成の案内は不要
+    if (!isQuestionable) {
+        // 模倣の未完成
+        const is_original = document.getElementById("is-original").checked;
+        const is_subeana = document.getElementById("is-subeana").checked;
+        if (!is_original && is_subeana && (imitateEle.value == "") && (authorsEle.value != "全てあなたの所為です。")) {
+            message += "<li>「オリジナル模倣」にチェックをつけるか、模倣曲を1曲以上登録してください。</li>"
+            is_lack = true;
+        }
+
+        // 歌詞の未完成
+        if (!document.getElementById("is-inst").checked && (lyricsEle.value == "")) {
+            message += "<li>「インスト」にチェックをつけるか、歌詞を入力してください。</li>"
+            is_lack = true;
+        }
     }
     
     // 登録ボタンの下のメッセージ

--- a/subekashi/static/subekashi/js/song_new.js
+++ b/subekashi/static/subekashi/js/song_new.js
@@ -6,6 +6,7 @@ async function init() {
     urlEle.focus();     // #urlにカーソルをあわせる
     await checkAutoForm();
     await checkManualForm();
+    updateQuestionableVisibility();
 };
 window.addEventListener('load', init);
 
@@ -16,8 +17,18 @@ document.querySelectorAll('input[type="checkbox"]').forEach(checkbox => {
         document.querySelectorAll(`input[data-sync="${syncGroup}"]`).forEach(cb => {
             cb.checked = this.checked;
         });
+        updateQuestionableVisibility();
     });
 });
+
+// 界隈曲?チェック時、オリジナル模倣を非表示にする
+function updateQuestionableVisibility() {
+    const checked = document.querySelectorAll('input[data-sync="questionable"]:checked').length > 0;
+    document.querySelectorAll('[data-hide-if-questionable]').forEach(el => {
+        el.style.display = checked ? 'none' : '';
+    });
+}
+updateQuestionableVisibility();
 
 // URL入力フォームの入力チェック
 async function checkAutoForm() {

--- a/subekashi/templates/subekashi/base/header.html
+++ b/subekashi/templates/subekashi/base/header.html
@@ -18,7 +18,7 @@
             {% if is_maintenance %}
                 <a href="{% url 'subekashi:top' %}">メンテナンス中です。</a>
             {% else %}
-                <a href="{% url 'subekashi:top' %}">全て歌詞の所為です。</a>
+                <a href="{% url 'subekashi:top' %}" class="sansfont">全て歌詞の所為です。</a>
             {% endif %}
         </div>
         {% if pc_menu_position == "header" %}

--- a/subekashi/templates/subekashi/components/song_card.html
+++ b/subekashi/templates/subekashi/components/song_card.html
@@ -10,7 +10,9 @@
         <tr>
             <td class="song-card-col1" title="{{ song.authors.all|join:', ' }}">{% get_author song %}</td>
             <td class="song-card-view">{% get_view song %}</td>
-            <td class="song-card-lyrics">{% get_lyrics song %}</td>
+            {% if not song.is_questionable %}
+                <td class="song-card-lyrics">{% get_lyrics song %}</td>
+            {% endif %}
         </tr>
     </table>
 </a>

--- a/subekashi/templates/subekashi/song.html
+++ b/subekashi/templates/subekashi/song.html
@@ -7,6 +7,14 @@
 {% block css %}{% static 'subekashi/css/song.css'%}{% endblock %}
 
 {% block content %}
+{% if song.is_questionable %}
+    <style>
+        html {
+            background-color: #003;
+            font-family: 'Noto Sans JP', 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', sans-serif;
+        }
+    </style>
+{% endif %}
 <section>
     <div class="dummybuttons">
         {% if not song.is_lock %}
@@ -26,7 +34,7 @@
                 <i class="fas fa-music"></i><p>曲名</p>
 
             </td>
-            <td class="sansfont">
+            <td{% if not song.is_questionable %} class="sansfont"{% endif %}>
                 {{ song.title }}
             </td>
         </tr>
@@ -59,7 +67,7 @@
                 </td>
                 <td>
                     {% if is_questionable %}
-                        <p id="special-tag">界隈曲(?)<i class="fas fa-info-circle" onclick="showTutorial('is_questionable')"></i></p>
+                        <p id="special-tag">界隈曲?<i class="fas fa-info-circle" onclick="showTutorial('is_questionable')"></i></p>
                     {% endif %}
                     {% if is_lack %}
                         <a href="{% url 'subekashi:songs' %}?is_lack=True">未完成</a>

--- a/subekashi/templates/subekashi/song_edit.html
+++ b/subekashi/templates/subekashi/song_edit.html
@@ -37,8 +37,8 @@
             <input type="text" id="url" name="url" value="{{ song.links.all|join:',' }}">
         </div>
         <p class="song-edit-info" id="song-edit-info-url"><span class='loading'></span></p>
-        <label id="imitate-label">模倣<i class="fas fa-info-circle" onclick="showTutorial('imitate')"></i></label>
-        <div id="imitate-div">
+        <label id="imitate-label" data-hide-if-questionable>模倣<i class="fas fa-info-circle" onclick="showTutorial('imitate')"></i></label>
+        <div id="imitate-div" data-hide-if-questionable>
             <p>原曲から選択</p>
             {% render_categorys %}
             <p id="imitate-sub">もしくは模倣曲から選択</p>
@@ -62,11 +62,11 @@
             <div id="imitate-list"></div>
             <input type="text" id="imitate" name="imitate" value="{% for s in song.imitates.all %}{{ s.id }}{% if not forloop.last %},{% endif %}{% endfor %}" hidden>
         </div>
-        <div class="form-col">
+        <div class="form-col" data-hide-if-questionable>
             <label for="lyrics">歌詞<i class="fas fa-info-circle" onclick="showTutorial('lyrics')"></i></label>
             <textarea id="lyrics" name="lyrics">{{ song.lyrics }}</textarea>
         </div>
-        <div class="checkbox-col">
+        <div class="checkbox-col" data-hide-if-questionable>
             <input type="checkbox" id="is-original" name="is_original" {% if song.is_original %}checked{% endif %}>
             <label for="is-original">オリジナル模倣</label>
             <i class="fas fa-info-circle" onclick="showTutorial('is-original')"></i>
@@ -91,10 +91,15 @@
             <label for="is-subeana">すべあな界隈曲</label>
             <i class="fas fa-info-circle" onclick="showTutorial('is-subeana')"></i>
         </div>
-        <div class="checkbox-col">
+        <div class="checkbox-col" data-hide-if-questionable>
             <input type="checkbox" id="is-draft" name="is_draft" {% if song.is_draft %}checked{% endif %}>
             <label for="is-draft">下書き</label>
             <i class="fas fa-info-circle" onclick="showTutorial('is-draft')"></i>
+        </div>
+        <div class="checkbox-col">
+            <input type="checkbox" id="is-questionable" name="is_questionable" {% if song.is_questionable %}checked{% endif %}>
+            <label for="is-questionable">界隈曲?</label>
+            <i class="fas fa-info-circle" onclick="showTutorial('is_questionable')"></i>
         </div>
         <input type="submit" value="登録" id="song-edit-submit" disabled>
         <p id="song-edit-info-submit" class="song-edit-info"><span class='loading'></span></p>

--- a/subekashi/templates/subekashi/song_new.html
+++ b/subekashi/templates/subekashi/song_new.html
@@ -13,7 +13,7 @@
             <label for="url">YouTubeの<br>動画リンク<i class="fas fa-info-circle" onclick="showTutorial('youtube-url')"></i></label>
             <input type="url" id="url" name="url" value="{{ request.GET.url }}" required>
         </div>
-        <div class="checkbox-col">
+        <div class="checkbox-col" data-hide-if-questionable>
             <input type="checkbox" id="is-original-auto" name="is-original-auto" data-sync="original">
             <label for="is-original-auto">オリジナル模倣</label>
             <i class="fas fa-info-circle" onclick="showTutorial('is-original')"></i>
@@ -38,6 +38,11 @@
             <label for="is-subeana-auto">すべあな界隈曲</label>
             <i class="fas fa-info-circle" onclick="showTutorial('is-subeana')"></i>
         </div>
+        <div class="checkbox-col">
+            <input type="checkbox" id="is-questionable-auto" name="is-questionable-auto" data-sync="questionable">
+            <label for="is-questionable-auto">界隈曲?</label>
+            <i class="fas fa-info-circle" onclick="showTutorial('is_questionable')"></i>
+        </div>
         <input type="submit" value="登録" id="new-submit-auto" disabled>
         <p id="new-form-auto-info"><span class='loading'></span></p>
     </form>
@@ -52,7 +57,7 @@
             <label for="authors">作者<br>(複数可)<i class="fas fa-info-circle" onclick="showTutorial('authors')"></i></label>
             <input type="text" id="authors" name="authors" class="sansfont" value="{{ request.GET.authors }}" required>
         </div>
-        <div class="checkbox-col">
+        <div class="checkbox-col" data-hide-if-questionable>
             <input type="checkbox" id="is-original-manual" name="is-original-manual" data-sync="original">
             <label for="is-original-manual">オリジナル模倣</label>
             <i class="fas fa-info-circle" onclick="showTutorial('is-original')"></i>
@@ -76,6 +81,11 @@
             <input type="checkbox" id="is-subeana-manual" name="is-subeana-manual" data-sync="subeana" checked>
             <label for="is-subeana-manual">すべあな界隈曲</label>
             <i class="fas fa-info-circle" onclick="showTutorial('is-subeana')"></i>
+        </div>
+        <div class="checkbox-col">
+            <input type="checkbox" id="is-questionable-manual" name="is-questionable-manual" data-sync="questionable">
+            <label for="is-questionable-manual">界隈曲?</label>
+            <i class="fas fa-info-circle" onclick="showTutorial('is_questionable')"></i>
         </div>
         <input type="submit" value="登録" id="new-submit-manual" disabled>
         <p id="new-form-manual-info"><span class='loading'></span></p>

--- a/subekashi/templates/subekashi/songs.html
+++ b/subekashi/templates/subekashi/songs.html
@@ -142,6 +142,10 @@
             <input type="checkbox" value="is_deleted" id="is_deleted" {% if is_deleted %}checked{% endif %}>
             <label for="is_deleted">非公開/削除済み</label>
         </div>
+        <div class="checkbox-col">
+            <input type="checkbox" value="is_questionable" id="is_questionable" {% if is_questionable %}checked{% endif %}>
+            <label for="is_questionable">界隈曲?</label>
+        </div>
     </details>
     <input type="submit" id="search-button" value="検索" onclick="renderSearch()"></input>
     <div id="song-cards"></div>

--- a/subekashi/tests/TEST_PLAN_INTEGRATION.md
+++ b/subekashi/tests/TEST_PLAN_INTEGRATION.md
@@ -73,6 +73,14 @@
 | 検証: レスポンス | HTTP 200、`context["error"]` に重複を示すメッセージを含む |
 | 検証: DB | 新たな Song は作成されていない |
 
+#### 1-5. is_questionable 登録時、オリジナル模倣は強制OFF・その他の入力値はそのまま保存される
+
+| 項目 | 内容 |
+| --- | --- |
+| 操作 | `POST /songs/new/` `{title="曲名", authors="作者", is-questionable-manual="on", is-original-manual="on", is-subeana-manual="on"}` |
+| 検証: レスポンス | `/songs/<id>/edit` へリダイレクト (302) |
+| 検証: Song | `is_questionable == True`、`is_original == False`（強制OFF）、`is_subeana == True`（曲名・作者・URLに加え非公開/削除済み・ネタ曲・インスト・すべあな界隈曲の入力値はそのまま保存される） |
+
 ---
 
 ### 2. 曲編集フロー
@@ -142,6 +150,23 @@
 | 操作 | `GET /songs/<id>/edit/` または `POST /songs/<id>/edit/` |
 | 検証 | `/songs/<id>?toast=lock` へリダイレクト (302) |
 | 検証 | Song は変更されていない |
+
+#### 2-8. is_questionable 編集時、歌詞・模倣・下書き・オリジナル模倣は強制的に空/OFFで保存される
+
+| 項目 | 内容 |
+| --- | --- |
+| 前提 | `lyrics`・`imitates`・`is_draft`・`is_original` などが設定済みの曲が存在する |
+| 操作 | `POST /songs/<id>/edit/` `{title=..., authors=..., is_questionable=True, lyrics="...", imitate="<id>", is_draft=True, is_original=True}` |
+| 検証: レスポンス | `/songs/<id>?toast=edit` へリダイレクト (302) |
+| 検証: Song | `is_questionable == True`、`lyrics == ""`、`imitates` が空、`is_draft == False`、`is_original == False`（曲名・作者・URLはそのまま保存） |
+
+#### 2-9. is_questionable 編集時も、非公開/削除済み・ネタ曲・インスト・すべあな界隈曲の入力値はそのまま保存される
+
+| 項目 | 内容 |
+| --- | --- |
+| 操作 | `POST /songs/<id>/edit/` `{title=..., authors=..., is_questionable=True, is_deleted=True, is_joke=True, is_inst=True, is_subeana=True}` |
+| 検証: レスポンス | `/songs/<id>?toast=edit` へリダイレクト (302) |
+| 検証: Song | `is_questionable == True`、`is_deleted`・`is_joke`・`is_inst`・`is_subeana` がすべて入力通り `True` で保存される |
 
 ---
 
@@ -241,6 +266,9 @@
 | 前提 | URL なし・歌詞なし曲と、URL あり・歌詞あり曲が存在する |
 | 操作 | `GET /api/song/?lack=true` |
 | 検証 | 未完成曲のみ返される |
+| 前提（is_questionable） | URL なし・歌詞なしだが `is_questionable=True` の曲が存在する |
+| 操作 | `GET /api/song/?lack=true` |
+| 検証 | `is_questionable=True` の曲は未完成条件を満たしていても結果に含まれない |
 
 #### 5-5. SongsView ページでの検索
 

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -103,6 +103,7 @@
 | 正常な曲作成 | 有効な `SongFields` | Songオブジェクトが保存される |
 | `post_time` が自動設定される | fields に `post_time` なし | `timezone.now()` に近い時刻が設定される |
 | 各フラグが正しく設定される | `is_original=True`, `is_joke=False` など | Song属性がfieldsと一致する |
+| `is_questionable` が正しく設定される | `is_questionable=True` | `song.is_questionable` が `True` |
 
 #### 2-4. `get_imitate_songs(imitates_str, self_id)`
 
@@ -122,6 +123,7 @@
 | 他の曲に紐付かないURLは完全削除 | URLが他の曲にない | SongLinkレコードごと削除される |
 | 新しいURLの追加 | 新しいURL | SongLinkが作成・紐付けられる |
 | 作者の更新 | 新しい author_objects | Song.authors が更新される |
+| `is_questionable` の更新 | `is_questionable=True` | `song.is_questionable` が `True` に更新される |
 | トランザクション失敗時のロールバック | DB エラーを模擬 | 変更が元に戻る |
 
 #### 2-6. `build_delete_discord_text(song, reason, editor)`
@@ -137,6 +139,7 @@
 | タイトル変更 | before と after が異なるタイトル | 変更差分が `changes` リストに含まれる |
 | 変更なし | before と after が同じ | `changed_labels` が空リスト |
 | 複数フィールドの変更 | 複数の差分 | 全変更が `changes` に含まれ、`edit_title` に反映 |
+| `is_questionable` の変更 | before/after で `is_questionable` が異なる | `changed_labels` に「界隈曲?」が含まれる |
 
 ---
 
@@ -161,6 +164,7 @@
 | URLなし・削除されていない曲 | `is_deleted=False`, SongLink なし | 結果に含まれる |
 | 歌詞なし・インストではない曲 | `is_inst=False`, `lyrics=""` | 結果に含まれる |
 | すべて完備している曲 | URL・歌詞・作者あり | 結果に含まれない |
+| `is_questionable=True` の曲 | 他の未完成条件を満たしていても `is_questionable=True` | 無条件で結果に含まれない（常に完成扱い） |
 
 #### 3-3. `filter_by_mediatypes(mediatypes)`
 
@@ -178,6 +182,7 @@
 | --- | --- | --- |
 | 未完成の曲に annotate | 上記の `filter_by_lack` と同じ条件 | `is_lack=True` がアノテートされる |
 | 完成した曲に annotate | URLと歌詞が揃っている曲 | `is_lack=False` がアノテートされる |
+| `is_questionable=True` の曲に annotate | 他の未完成条件を満たしていても `is_questionable=True` | 無条件で `is_lack=False` がアノテートされる |
 
 ---
 
@@ -268,6 +273,7 @@
 | authorsが空 | `title="タイトル"`, `authors=""` | `is_valid() == False`、`"作者は空白にできません。"` |
 | urlは任意 | `url=""` (省略) | `is_valid() == True` |
 | is_original など boolean フラグ | `is_original=True` | `cleaned_data["is_original"] == True` |
+| is_questionable boolean フラグ | `is_questionable=True` | `cleaned_data["is_questionable"] == True` |
 | titleが500文字超 | `title="あ" * 501` | `is_valid() == False` |
 
 ---
@@ -301,6 +307,7 @@
 | is_joke=all | `?is_joke=all` | context["jokerange"] = "on" |
 | is_joke=on | `?is_joke=on` | context["jokerange"] = "on" |
 | is_original/is_inst 大文字True | `?is_original=True` など | 対応 context フィールドが True |
+| is_questionable 大文字True | `?is_questionable=True` | context["is_questionable"] = True |
 
 #### 7-3. `SongView` (`/songs/<id>/`)
 
@@ -309,6 +316,8 @@
 | 存在する曲ID | 有効なsong_id | HTTP 200 |
 | 存在しない曲ID | 無効なsong_id | HTTP 404 |
 | 削除済み曲 | `is_deleted=True` の曲 | HTTP 404 または特定の表示 |
+| is_questionable=True の曲 | `is_questionable=True` の曲 | レスポンスに「界隈曲?」タグが含まれる |
+| is_questionable=False の曲 | デフォルトの曲 | レスポンスに「界隈曲?」タグが含まれない |
 
 #### 7-4. `SongNewView` (`/songs/new/`)
 
@@ -318,6 +327,7 @@
 | POST: YouTube以外のURL | `url="https://example.com/..."` | HTTP 200、"YouTube" を含むエラー |
 | POST: 作者が空白 | `url=""`, `authors="  "` | HTTP 200、"作者" を含むエラー |
 | POST: タイトルが空 | `url=""`, `authors="テスト作者"`, `title=""` | HTTP 200、"タイトル" を含むエラー |
+| POST: is-questionable時、オリジナル模倣は強制OFF・その他フラグの入力値はそのまま保存される | `is-questionable-manual=on`, `is-original-manual=on`, `is-subeana-manual=on` | 保存されたSongの `is_questionable=True`、`is_original=False`、`is_subeana=True` |
 
 #### 7-5. `SongEditView` (`/songs/<id>/edit/`)
 
@@ -325,6 +335,8 @@
 | --- | --- | --- |
 | 存在する曲のGET | 有効なsong_id | HTTP 200 |
 | 存在しない曲のGET | 無効なsong_id | HTTP 404 |
+| POST: is_questionable時に歌詞・模倣・下書き・オリジナル模倣が強制的に空/OFF | `is_questionable=True`, `lyrics="..."`, `imitate="<id>"`, `is_draft=True`, `is_original=True` | 保存されたSongの `lyrics=""`、`imitates`が空、`is_draft=False`、`is_original=False`、`is_questionable=True` |
+| POST: is_questionable時も非公開/削除済み・ネタ曲・インスト・すべあな界隈曲は保存される | `is_questionable=True`, `is_deleted=True`, `is_joke=True`, `is_inst=True`, `is_subeana=True` | 各フラグがそれぞれ `True` のまま保存される |
 
 #### 7-6. `ContactView` (`/contact/`)
 
@@ -371,6 +383,8 @@
 | `sort=-upload_time` | GETリクエスト | HTTP 200、「YouTubeの曲を表示しています」が含まれる |
 | ソート指定なし | GETリクエスト | 投稿日用のsearch-infoが含まれない |
 | `sort=title` | GETリクエスト | 投稿日用のsearch-infoが含まれない |
+| `is_questionable=True` の曲 | GETリクエスト | カードHTMLに `song-card-lyrics` が含まれない |
+| `is_questionable=False` の曲 | GETリクエスト | カードHTMLに `song-card-lyrics` が含まれる |
 
 ---
 
@@ -457,6 +471,7 @@
 | --- | --- | --- |
 | 曲の作成 | `Song.objects.create(title="テスト曲", ...)` | DBに保存される |
 | `authors_str()` メソッド | 複数作者を持つ曲 | 作者名がカンマ区切りで返される |
+| `is_questionable` のデフォルト値 | フラグ未指定で作成 | `is_questionable == False` |
 | `is_deleted=True` の曲 | 削除フラグを立てる | DBに残るが削除済みとして扱われる |
 | ManyToMany: authors | `song.authors.add(author)` | 作者が曲に紐付く |
 | ManyToMany: imitates (自己参照) | `song.imitates.add(other_song)` | 模倣関係が成立する |

--- a/subekashi/tests/test_forms.py
+++ b/subekashi/tests/test_forms.py
@@ -135,8 +135,13 @@ class SongEditFormTest(SimpleTestCase):
     def test_boolean_flags_default_to_false(self):
         form = SongEditForm(data=self._make_data())
         form.is_valid()
-        for field in ["is_original", "is_deleted", "is_joke", "is_inst", "is_subeana", "is_draft"]:
+        for field in ["is_original", "is_deleted", "is_joke", "is_inst", "is_subeana", "is_draft", "is_questionable"]:
             self.assertFalse(form.cleaned_data[field], f"{field} のデフォルトが False でない")
+
+    def test_boolean_flag_is_questionable_true(self):
+        form = SongEditForm(data=self._make_data(is_questionable=True))
+        self.assertTrue(form.is_valid())
+        self.assertTrue(form.cleaned_data["is_questionable"])
 
     def test_all_optional_fields_provided(self):
         form = SongEditForm(data=self._make_data(

--- a/subekashi/tests/test_lib_query_filters.py
+++ b/subekashi/tests/test_lib_query_filters.py
@@ -158,6 +158,14 @@ class FilterByLackTest(TestCase):
         qs = Song.objects.filter(filter_by_lack())
         self.assertNotIn(song, qs)
 
+    def test_questionable_song_is_never_lack(self):
+        # is_questionable=True の場合、他の条件を満たしていても無条件で完成扱いになる
+        song = Song.objects.create(
+            title="界隈曲テスト", is_questionable=True, is_deleted=False, lyrics="", is_inst=False, is_original=False,
+        )
+        qs = Song.objects.filter(filter_by_lack())
+        self.assertNotIn(song, qs)
+
 
 class FilterByMediatypesTest(TestCase):
     """filter_by_mediatypes() のテスト
@@ -211,6 +219,13 @@ class MakeIsLackAnnotationTest(TestCase):
         song = Song.objects.create(title="完成曲", lyrics="歌詞あり", is_original=True)
         link = SongLink.objects.create(url="https://youtu.be/complete00001")
         link.songs.add(song)
+        qs = Song.objects.annotate(is_lack=make_is_lack_annotation())
+        annotated = qs.get(pk=song.pk)
+        self.assertFalse(annotated.is_lack)
+
+    def test_questionable_song_annotated_false(self):
+        # is_questionable=True の場合、他の条件を満たしていても無条件で is_lack=False
+        song = Song.objects.create(title="界隈曲アノテーションテスト", is_questionable=True, is_inst=False, lyrics="")
         qs = Song.objects.annotate(is_lack=make_is_lack_annotation())
         annotated = qs.get(pk=song.pk)
         self.assertFalse(annotated.is_lack)

--- a/subekashi/tests/test_lib_song_service.py
+++ b/subekashi/tests/test_lib_song_service.py
@@ -129,6 +129,11 @@ class CreateSongTest(TestCase):
         self.assertTrue(song.is_inst)
         self.assertFalse(song.is_subeana)
 
+    def test_is_questionable_is_set(self):
+        fields = SongFields(title="界隈曲テスト", is_questionable=True)
+        song = create_song(fields)
+        self.assertTrue(song.is_questionable)
+
     def test_post_time_is_set_automatically(self):
         before = timezone.now()
         fields = SongFields(title="タイムスタンプテスト曲")
@@ -269,6 +274,12 @@ class UpdateSongTest(TestCase):
         urls = list(self.song.links.values_list("url", flat=True))
         self.assertIn(new_url, urls)
 
+    def test_is_questionable_is_updated(self):
+        fields = SongFields(title="更新前タイトル", lyrics="更新前歌詞", is_questionable=True)
+        update_song(self.song, fields, [self.author1], [], ["https://youtu.be/beforeupdate1"])
+        self.song.refresh_from_db()
+        self.assertTrue(self.song.is_questionable)
+
     def test_imitates_are_updated(self):
         target_song = Song.objects.create(title="新しい模倣元")
         fields = SongFields(title="更新前タイトル", lyrics="更新前歌詞")
@@ -337,6 +348,13 @@ class BuildNewSongDiscordTextTest(TestCase):
         )
         self.assertIn("新規テスト作者", text)
 
+    def test_text_contains_questionable_label_when_true(self):
+        fields = SongFields(title="新規テスト曲", is_questionable=True)
+        _, text = build_new_song_discord_text(
+            self.song.id, fields, [self.author], "", "editor_ip"
+        )
+        self.assertIn("界隈曲?", text)
+
 
 class BuildEditSongDiscordTextTest(TestCase):
     """build_edit_song_discord_text() のテスト"""
@@ -382,3 +400,10 @@ class BuildEditSongDiscordTextTest(TestCase):
         self.assertIn("タイトル", changed_labels)
         self.assertIn("歌詞", changed_labels)
         self.assertIn("オリジナル", changed_labels)
+
+    def test_is_questionable_change_is_detected(self):
+        fields = SongFields(title="編集前タイトル", lyrics="編集前歌詞", is_questionable=True)
+        _, _, _, changed_labels = build_edit_song_discord_text(
+            self.song.id, self.song, fields, [self.author], "", []
+        )
+        self.assertIn("界隈曲?", changed_labels)

--- a/subekashi/tests/test_models.py
+++ b/subekashi/tests/test_models.py
@@ -95,6 +95,7 @@ class SongModelTest(TestCase):
         self.assertFalse(song.is_draft)
         self.assertFalse(song.is_inst)
         self.assertTrue(song.is_subeana)
+        self.assertFalse(song.is_questionable)
 
     def test_add_single_author(self):
         song = Song.objects.create(title="単一作者曲")

--- a/subekashi/tests/test_views.py
+++ b/subekashi/tests/test_views.py
@@ -103,8 +103,8 @@ class SongsViewTest(TestCase):
         self.assertEqual(response.context["jokerange"], "on")
 
     def test_bool_query_params_all_fields(self):
-        """is_original/is_inst でもTrue/Falseが正しく変換されること"""
-        for field in ["is_original", "is_inst"]:
+        """is_original/is_inst/is_questionable でもTrue/Falseが正しく変換されること"""
+        for field in ["is_original", "is_inst", "is_questionable"]:
             with self.subTest(field=field):
                 response = self.client.get(reverse("subekashi:songs"), {field: "True"})
                 self.assertEqual(response.status_code, 200)
@@ -130,6 +130,16 @@ class SongViewTest(TestCase):
     def test_song_title_appears_in_response(self):
         response = self.client.get(reverse("subekashi:song", args=[self.song.id]))
         self.assertContains(response, "詳細テスト曲")
+
+    def test_questionable_tag_appears_when_is_questionable(self):
+        self.song.is_questionable = True
+        self.song.save()
+        response = self.client.get(reverse("subekashi:song", args=[self.song.id]))
+        self.assertContains(response, "界隈曲?")
+
+    def test_questionable_tag_not_shown_by_default(self):
+        response = self.client.get(reverse("subekashi:song", args=[self.song.id]))
+        self.assertNotContains(response, "界隈曲?")
 
 
 @override_settings(STATICFILES_STORAGE=STATIC_STORAGE)
@@ -169,6 +179,25 @@ class SongNewViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("タイトル", response.context["error"])
 
+    def test_post_questionable_forces_original_false(self):
+        # is-questionable時、オリジナル模倣はユーザーの入力値に関わらず強制的にFalseになる
+        response = self.client.post(
+            reverse("subekashi:song_new"),
+            {
+                "url": "",
+                "authors": "界隈曲テスト作者",
+                "title": "界隈曲テスト曲",
+                "is-questionable-manual": "on",
+                "is-original-manual": "on",
+                "is-subeana-manual": "on",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        song = Song.objects.get(title="界隈曲テスト曲")
+        self.assertTrue(song.is_questionable)
+        self.assertFalse(song.is_original)
+        self.assertTrue(song.is_subeana)
+
 
 @override_settings(STATICFILES_STORAGE=STATIC_STORAGE)
 class SongEditViewTest(TestCase):
@@ -185,6 +214,56 @@ class SongEditViewTest(TestCase):
     def test_nonexistent_song_returns_404(self):
         response = self.client.get(reverse("subekashi:song_edit", args=[99999]))
         self.assertEqual(response.status_code, 404)
+
+    def test_post_questionable_forces_lyrics_and_imitate_blank(self):
+        # is_questionable時、歌詞・模倣・下書きはユーザー入力に関わらず空/OFFになる
+        imitate_target = Song.objects.create(title="模倣元テスト曲")
+        response = self.client.post(
+            reverse("subekashi:song_edit", args=[self.song.id]),
+            {
+                "title": "編集テスト曲",
+                "authors": "編集テスト作者",
+                "url": "",
+                "imitate": str(imitate_target.id),
+                "lyrics": "本来は保存されないはずの歌詞",
+                "is_questionable": True,
+                "is_draft": True,
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.song.refresh_from_db()
+        self.assertTrue(self.song.is_questionable)
+        self.assertEqual(self.song.lyrics, "")
+        self.assertFalse(self.song.is_draft)
+        self.assertNotIn(imitate_target, self.song.imitates.all())
+
+    def test_post_questionable_honors_deleted_joke_inst_subeana_but_forces_original_false(self):
+        # is_questionable時、非公開/削除済み・ネタ曲・インスト・すべあな界隈曲の入力値は保存されるが、
+        # オリジナル模倣は入力値に関わらず強制的にFalseになる
+        response = self.client.post(
+            reverse("subekashi:song_edit", args=[self.song.id]),
+            {
+                "title": "編集テスト曲",
+                "authors": "編集テスト作者",
+                "url": "",
+                "imitate": "",
+                "lyrics": "",
+                "is_questionable": True,
+                "is_original": True,
+                "is_deleted": True,
+                "is_joke": True,
+                "is_inst": True,
+                "is_subeana": True,
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.song.refresh_from_db()
+        self.assertTrue(self.song.is_questionable)
+        self.assertFalse(self.song.is_original)
+        self.assertTrue(self.song.is_deleted)
+        self.assertTrue(self.song.is_joke)
+        self.assertTrue(self.song.is_inst)
+        self.assertTrue(self.song.is_subeana)
 
 
 @override_settings(STATICFILES_STORAGE=STATIC_STORAGE)
@@ -375,6 +454,25 @@ class SongCardsViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         content = "".join(response.json())
         self.assertNotIn("YouTubeの曲を表示しています", content)
+
+    def test_questionable_song_card_hides_lyrics(self):
+        """is_questionable=True の曲のカードには .song-card-lyrics が含まれないこと"""
+        Song.objects.create(title="界隈曲カードテスト", is_questionable=True)
+        response = self.client.get(
+            reverse("subekashi:song_cards"), {"keyword": "界隈曲カードテスト"}
+        )
+        self.assertEqual(response.status_code, 200)
+        content = "".join(response.json())
+        self.assertNotIn("song-card-lyrics", content)
+
+    def test_normal_song_card_shows_lyrics(self):
+        """is_questionable=False の曲のカードには .song-card-lyrics が含まれること"""
+        response = self.client.get(
+            reverse("subekashi:song_cards"), {"keyword": "カードテスト曲"}
+        )
+        self.assertEqual(response.status_code, 200)
+        content = "".join(response.json())
+        self.assertIn("song-card-lyrics", content)
 
 
 @override_settings(STATICFILES_STORAGE=STATIC_STORAGE)

--- a/subekashi/views/song.py
+++ b/subekashi/views/song.py
@@ -46,7 +46,7 @@ class SongView(View):
         # タグを持っているかどうかの確認
         has_tag = any([
             is_lack, song.is_draft, song.is_original, song.is_joke, song.is_inst, song.is_deleted, song.is_limited,
-            not song.is_subeana
+            song.is_questionable, not song.is_subeana
         ])
 
         context = {
@@ -60,6 +60,6 @@ class SongView(View):
             "imitate_list": imitate_list,
             "imitated_list": imitated_list,
             "has_tag": has_tag,
-            "is_questionable": song_id in [6570, 7989, 8000, 8012, 8016]
+            "is_questionable": song.is_questionable,
         }
         return render(request, "subekashi/song.html", context)

--- a/subekashi/views/song_edit.py
+++ b/subekashi/views/song_edit.py
@@ -68,6 +68,14 @@ class SongEditView(View):
         is_inst = form.cleaned_data['is_inst']
         is_subeana = form.cleaned_data['is_subeana']
         is_draft = form.cleaned_data['is_draft']
+        is_questionable = form.cleaned_data['is_questionable']
+
+        # is_questionableの場合、模倣・歌詞・下書き・オリジナル模倣はユーザーの入力値に関わらず空にする
+        if is_questionable:
+            imitates = ""
+            lyrics = ""
+            is_draft = False
+            is_original = False
 
         # URLのバリデーション
         cleaned_url = clean_url(url)
@@ -113,6 +121,7 @@ class SongEditView(View):
             is_inst=is_inst,
             is_subeana=is_subeana,
             is_draft=is_draft,
+            is_questionable=is_questionable,
         )
 
         # Discordテキストとchangesを構築（song更新前に実行）

--- a/subekashi/views/song_new.py
+++ b/subekashi/views/song_new.py
@@ -47,6 +47,11 @@ class SongNewView(View):
         is_joke = bool(request.POST.get("is-joke-auto", "") + request.POST.get("is-joke-manual", ""))
         is_inst = bool(request.POST.get("is-inst-auto", "") + request.POST.get("is-inst-manual", ""))
         is_subeana = bool(request.POST.get("is-subeana-auto", "") + request.POST.get("is-subeana-manual", ""))
+        is_questionable = bool(request.POST.get("is-questionable-auto", "") + request.POST.get("is-questionable-manual", ""))
+
+        # is_questionableの場合、オリジナル模倣はユーザーの入力値に関わらず空にする
+        if is_questionable:
+            is_original = False
 
         # YouTube APIから情報取得
         youtube_res = {}
@@ -105,6 +110,7 @@ class SongNewView(View):
             is_joke=is_joke,
             is_inst=is_inst,
             is_subeana=is_subeana,
+            is_questionable=is_questionable,
             upload_time=youtube_res.get("upload_time", None),
             view=youtube_res.get("view", None),
             like=youtube_res.get("like", None),

--- a/subekashi/views/songs.py
+++ b/subekashi/views/songs.py
@@ -24,7 +24,7 @@ COOKIE_FORMS = {
 }
 
 # チェックボックス
-BOOL_FORMS = ["is_subeana", "is_joke", "is_lack", "is_draft", "is_original", "is_inst", "is_deleted"]
+BOOL_FORMS = ["is_subeana", "is_joke", "is_lack", "is_draft", "is_original", "is_inst", "is_deleted", "is_questionable"]
 
 # 折りたたまれていないメディアタイプ
 DISPLAY_MEDIA_INDEX = 5


### PR DESCRIPTION
## Summary
- `Song` に `is_questionable`（界隈曲?）カラムを追加し、登録・編集・検索・表示に対応 (close #478)
- is_questionableチェック時はオリジナル模倣・模倣・歌詞・下書きを非表示にし、ユーザー入力に関わらず強制的に空/OFFで保存する
- 未完成フィルター (`filter_by_lack`, `make_is_lack_annotation`, `isLack()`) は is_questionable な曲を無条件で完成扱いにする
- song card では is_questionable 時に `.song-card-lyrics`（歌詞プレビュー）を表示しない
- is_questionable な曲のページ (`song.html`) は html の背景色を `#003`、フォントを sans-serif にする
- 既存の対象曲(6570, 7989, 8000, 8012, 8016)にis_questionable=Trueを設定するデータマイグレーションを追加

## Test plan
- [x] `python manage.py test subekashi.tests article.tests`（347件全て成功）
- [x] `python manage.py makemigrations --check --dry-run`（差分なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)