### PR TITLE
[Fix] ヘッダーロゴ文言のフォントをImitateの強制適用に変更

### DIFF
--- a/subekashi/static/subekashi/css/common.css
+++ b/subekashi/static/subekashi/css/common.css
@@ -543,6 +543,10 @@ a {
     font-weight: 1000 !important;
 }
 
+.imitatefont {
+    font-family: 'Imitate', 'Noto Sans JP', 'Hiragino Kaku Gothic ProN', 'Hiragino Sans', sans-serif, Meiryo !important;
+}
+
 .info {
     color: #09F;
 }

--- a/subekashi/templates/subekashi/base/header.html
+++ b/subekashi/templates/subekashi/base/header.html
@@ -18,7 +18,7 @@
             {% if is_maintenance %}
                 <a href="{% url 'subekashi:top' %}">メンテナンス中です。</a>
             {% else %}
-                <a href="{% url 'subekashi:top' %}" class="sansfont">全て歌詞の所為です。</a>
+                <a href="{% url 'subekashi:top' %}" class="imitatefont">全て歌詞の所為です。</a>
             {% endif %}
         </div>
         {% if pc_menu_position == "header" %}


### PR DESCRIPTION
## Summary
- #976 でヘッダー「全て歌詞の所為です。」に付けた `sansfont` を撤回し、代わりに Imitate フォントを強制適用する `.imitatefont` クラスを追加
- `subekashi/static/subekashi/css/common.css`: `.imitatefont { font-family: 'Imitate', ... !important; }` を新規追加
- `subekashi/templates/subekashi/base/header.html`: `class="sansfont"` → `class="imitatefont"`

## Test plan
テストなし（CSS/テンプレートのみの変更）

🤖 Generated with [Claude Code](https://claude.com/claude-code)