### PR TITLE
[Fix] テスト実行時にDiscordへ実送信されてしまう不具合の修正

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -1,6 +1,11 @@
 from pathlib import Path
 import os
+import sys
 from .local_settings import *
+
+# テスト実行時は local_settings.py の値によらず Discord への送信を無効化する
+if 'test' in sys.argv:
+    SEND_DISCORD = False
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 STATIC_URL = '/static/'

--- a/subekashi/lib/discord.py
+++ b/subekashi/lib/discord.py
@@ -1,7 +1,6 @@
 import requests
 from time import sleep
-from config.settings import DEBUG
-from config.local_settings import SEND_DISCORD
+from config.settings import DEBUG, SEND_DISCORD
 
 
 def send_discord(url, content):


### PR DESCRIPTION
## Summary
- テスト実行時、開発者ローカルの `config/local_settings.py` の `SEND_DISCORD` 値に関わらず送信を無効化するようにした
- `subekashi/lib/discord.py` が `config.local_settings` から直接 `SEND_DISCORD` をインポートしていたため、`config/settings.py` 側の上書きが反映されず、テスト実行時に実際にDiscord Webhookへ送信されてしまう不具合を修正

## 背景
`config/local_settings.py`（gitignore対象）が `SEND_DISCORD = True` の環境で `python manage.py test` を実行すると、`send_discord()` の `DEBUG and not SEND_DISCORD` によるスキップ判定が効かず、実際にDiscordへメッセージが送信されてしまっていた。

## Test plan
- [x] `config/settings.py` で `'test' in sys.argv` の場合に `SEND_DISCORD = False` を設定
- [x] `subekashi/lib/discord.py` のインポート元を `config.settings` に変更し、上書きが反映されるよう修正
- [x] `python manage.py test subekashi.tests article.tests` を実行し347件全て成功、かつ実行時間短縮（12.5s→1.9s）により実送信が発生していないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)