### PR TITLE
[Add] is_questionable/is_limited時にnoindexを追加

### DIFF
--- a/subekashi/templates/subekashi/song.html
+++ b/subekashi/templates/subekashi/song.html
@@ -6,6 +6,10 @@
 
 {% block css %}{% static 'subekashi/css/song.css'%}{% endblock %}
 
+{% block noindex %}
+    {% if song.is_questionable or song.is_limited %}<meta name="robots" content="noindex, nofollow">{% endif %}
+{% endblock %}
+
 {% block content %}
 {% if song.is_questionable %}
     <style>

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -318,6 +318,9 @@
 | 削除済み曲 | `is_deleted=True` の曲 | HTTP 404 または特定の表示 |
 | is_questionable=True の曲 | `is_questionable=True` の曲 | レスポンスに「界隈曲?」タグが含まれる |
 | is_questionable=False の曲 | デフォルトの曲 | レスポンスに「界隈曲?」タグが含まれない |
+| デフォルトの曲 | `is_questionable=False`, `is_limited=False` | レスポンスに `<meta name="robots">` が含まれない |
+| is_questionable=True の曲 | `is_questionable=True` の曲 | レスポンスに `<meta name="robots" content="noindex, nofollow">` が含まれる |
+| is_limited=True の曲 | `is_limited=True` の曲 | レスポンスに `<meta name="robots" content="noindex, nofollow">` が含まれる |
 
 #### 7-4. `SongNewView` (`/songs/new/`)
 

--- a/subekashi/tests/test_views.py
+++ b/subekashi/tests/test_views.py
@@ -141,6 +141,22 @@ class SongViewTest(TestCase):
         response = self.client.get(reverse("subekashi:song", args=[self.song.id]))
         self.assertNotContains(response, "界隈曲?")
 
+    def test_noindex_not_shown_by_default(self):
+        response = self.client.get(reverse("subekashi:song", args=[self.song.id]))
+        self.assertNotContains(response, 'name="robots"')
+
+    def test_noindex_shown_when_is_questionable(self):
+        self.song.is_questionable = True
+        self.song.save()
+        response = self.client.get(reverse("subekashi:song", args=[self.song.id]))
+        self.assertContains(response, '<meta name="robots" content="noindex, nofollow">')
+
+    def test_noindex_shown_when_is_limited(self):
+        self.song.is_limited = True
+        self.song.save()
+        response = self.client.get(reverse("subekashi:song", args=[self.song.id]))
+        self.assertContains(response, '<meta name="robots" content="noindex, nofollow">')
+
 
 @override_settings(STATICFILES_STORAGE=STATIC_STORAGE)
 class SongNewViewTest(TestCase):


### PR DESCRIPTION
## Summary
- 曲詳細ページ(song.html)で `is_questionable` または `is_limited` の曲の場合、`<meta name="robots" content="noindex, nofollow">` を出力するようにした
- base.html に既存の `{% block noindex %}` ブロックを利用（editor.html / song_edit.html / histories.html と同じパターン）

## Test plan
- [x] `SongViewTest` にテストケースを追加（デフォルト時は出力なし、`is_questionable=True`/`is_limited=True` 時にnoindex出力）
- [x] `TEST_PLAN_UNIT.md` を更新
- [x] `python manage.py test subekashi.tests article.tests` で全350件パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)