### PR TITLE
fix: 未完成判定条件BのPython/JS不一致を修正 (#983)

### DIFF
--- a/subekashi/static/subekashi/js/base.js
+++ b/subekashi/static/subekashi/js/base.js
@@ -424,7 +424,7 @@ function isLack(song) {
         ? song.authors.some(author => author.id === 1)
         : false;
 
-    if (!song.is_questionable && !song.is_original && !song.is_subeana && song.imitates.length === 0 && hasSpecialAuthor) {
+    if (!song.is_questionable && !song.is_original && song.is_subeana && song.imitates.length === 0 && !hasSpecialAuthor) {
         return true;
     }
 

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -164,6 +164,9 @@
 | URLなし・削除されていない曲 | `is_deleted=False`, SongLink なし | 結果に含まれる |
 | 歌詞なし・インストではない曲 | `is_inst=False`, `lyrics=""` | 結果に含まれる |
 | すべて完備している曲 | URL・歌詞・作者あり | 結果に含まれない |
+| `is_subeana=True` かつ特殊作者(id=1)なしの曲 | `is_original=False`, `is_subeana=True`, `imitates`なし, 特殊作者(id=1)の紐付けなし | 結果に含まれる |
+| 特殊作者(id=1)が紐づいている曲 | 上記に加え特殊作者(id=1)を紐付け | 結果に含まれない |
+| `is_subeana=False` の曲 | `is_original=False`, `is_subeana=False` | 結果に含まれない |
 | `is_questionable=True` かつURLなし・削除されていない曲 | `is_questionable=True`, `is_deleted=False`, SongLink なし | 結果に含まれる（URLなし条件は `is_questionable` を問わない） |
 | `is_questionable=True` かつ歌詞なし/模倣なし等の曲 | `is_questionable=True`, URLあり、歌詞なし等 | 結果に含まれない（歌詞なし・模倣なし条件は `is_questionable=False` が必須） |
 
@@ -183,6 +186,8 @@
 | --- | --- | --- |
 | 未完成の曲に annotate | 上記の `filter_by_lack` と同じ条件 | `is_lack=True` がアノテートされる |
 | 完成した曲に annotate | URLと歌詞が揃っている曲 | `is_lack=False` がアノテートされる |
+| `is_subeana=True` かつ特殊作者(id=1)なしの曲に annotate | `is_original=False`, `is_subeana=True`, `imitates`なし, 特殊作者(id=1)の紐付けなし | `is_lack=True` がアノテートされる |
+| 特殊作者(id=1)が紐づいている曲に annotate | 上記に加え特殊作者(id=1)を紐付け | `is_lack=False` がアノテートされる |
 | `is_questionable=True` かつURLなし・削除されていない曲に annotate | `is_questionable=True`, SongLink なし | `is_lack=True` がアノテートされる（URLなし条件は `is_questionable` を問わない） |
 | `is_questionable=True` かつ歌詞なし等の曲に annotate | `is_questionable=True`, URLあり、歌詞なし等 | `is_lack=False` がアノテートされる（歌詞なし条件は `is_questionable=False` が必須） |
 

--- a/subekashi/tests/test_lib_query_filters.py
+++ b/subekashi/tests/test_lib_query_filters.py
@@ -177,6 +177,39 @@ class FilterByLackTest(TestCase):
         qs = Song.objects.filter(filter_by_lack()).distinct()
         self.assertNotIn(song, qs)
 
+    def test_subeana_song_without_special_author_is_lack(self):
+        # 条件(B): is_subeana=True かつ 特殊作者(id=1)なし → 未完成
+        # URLあり(条件A除外)・歌詞あり(条件C除外)
+        song = Song.objects.create(
+            title="すべあな曲特殊作者なしテスト", is_original=False, is_subeana=True, lyrics="歌詞あり",
+        )
+        link = SongLink.objects.create(url="https://youtu.be/subeananoauthor01")
+        link.songs.add(song)
+        qs = Song.objects.filter(filter_by_lack()).distinct()
+        self.assertIn(song, qs)
+
+    def test_subeana_song_with_special_author_is_not_lack(self):
+        # 条件(B)を満たさない: 特殊作者(id=1)が紐づいている場合は未完成ではない
+        author = Author.objects.create(pk=1, name="全てあなたの所為です。")
+        song = Song.objects.create(
+            title="すべあな曲特殊作者ありテスト", is_original=False, is_subeana=True, lyrics="歌詞あり",
+        )
+        song.authors.add(author)
+        link = SongLink.objects.create(url="https://youtu.be/subeanawithauthor01")
+        link.songs.add(song)
+        qs = Song.objects.filter(filter_by_lack()).distinct()
+        self.assertNotIn(song, qs)
+
+    def test_non_subeana_song_without_special_author_is_not_lack(self):
+        # 条件(B)を満たさない: is_subeana=False の場合は特殊作者の有無に関わらず未完成ではない
+        song = Song.objects.create(
+            title="非すべあな曲テスト", is_original=False, is_subeana=False, lyrics="歌詞あり",
+        )
+        link = SongLink.objects.create(url="https://youtu.be/nonsubeana00001")
+        link.songs.add(song)
+        qs = Song.objects.filter(filter_by_lack()).distinct()
+        self.assertNotIn(song, qs)
+
 
 class FilterByMediatypesTest(TestCase):
     """filter_by_mediatypes() のテスト
@@ -248,6 +281,31 @@ class MakeIsLackAnnotationTest(TestCase):
         # 条件(A)に該当しなければ is_lack=False
         song = Song.objects.create(title="界隈曲アノテーションテスト", is_questionable=True, is_inst=False, lyrics="")
         link = SongLink.objects.create(url="https://youtu.be/questionable0002")
+        link.songs.add(song)
+        qs = Song.objects.annotate(is_lack=make_is_lack_annotation())
+        annotated = qs.get(pk=song.pk)
+        self.assertFalse(annotated.is_lack)
+
+    def test_subeana_song_without_special_author_annotated_true(self):
+        # 条件(B): is_subeana=True かつ 特殊作者(id=1)なし → is_lack=True
+        # URLあり(条件A除外)・歌詞あり(条件C除外)
+        song = Song.objects.create(
+            title="すべあな曲アノテーション特殊作者なしテスト", is_original=False, is_subeana=True, lyrics="歌詞あり",
+        )
+        link = SongLink.objects.create(url="https://youtu.be/subeananoauthor02")
+        link.songs.add(song)
+        qs = Song.objects.annotate(is_lack=make_is_lack_annotation())
+        annotated = qs.get(pk=song.pk)
+        self.assertTrue(annotated.is_lack)
+
+    def test_subeana_song_with_special_author_annotated_false(self):
+        # 条件(B)を満たさない: 特殊作者(id=1)が紐づいている場合は is_lack=False
+        author = Author.objects.create(pk=1, name="全てあなたの所為です。")
+        song = Song.objects.create(
+            title="すべあな曲アノテーション特殊作者ありテスト", is_original=False, is_subeana=True, lyrics="歌詞あり",
+        )
+        song.authors.add(author)
+        link = SongLink.objects.create(url="https://youtu.be/subeanawithauthor02")
         link.songs.add(song)
         qs = Song.objects.annotate(is_lack=make_is_lack_annotation())
         annotated = qs.get(pk=song.pk)


### PR DESCRIPTION
## Summary
- 「未完成」判定の条件B（`is_subeana`・特殊作者(id=1: 「全てあなたの所為です。」)の紐付け）について、Python側(`filter_by_lack()`/`make_is_lack_annotation()`)とJS側(`base.js`の`isLack()`)で真偽が逆になっていたバグを修正
- 意図した仕様（Python側: `is_subeana=True` かつ 特殊作者(id=1)が紐づいていない場合に未完成）に`isLack()`を合わせた
- 従来テストされていなかった条件Bの回帰テストを追加し、テスト計画書も更新

## Related
Closes #983

## Test plan
- [x] `python manage.py test subekashi.tests article.tests` (357件) がすべてパス
- [x] `filter_by_lack()`/`make_is_lack_annotation()`の条件B回帰テストを新規追加し、通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)