### PR TITLE
test: Pro未契約期間中に追加された機能・修正のテストを補完

### DIFF
--- a/article/tests.py
+++ b/article/tests.py
@@ -3,6 +3,8 @@ article アプリのビューテスト
 
 ArticlesView・DefaultArticleView の HTTP レスポンスを検証する。
 """
+from datetime import timedelta
+
 from django.test import TestCase, Client, override_settings
 from django.utils import timezone
 from article.models import Article
@@ -43,6 +45,97 @@ class ArticlesViewTest(TestCase):
     def test_keyword_no_match_returns_200(self):
         response = self.client.get("/articles/", {"keyword": "存在しないキーワードXYZ"})
         self.assertEqual(response.status_code, 200)
+
+    def test_is_pinned_article_default_pins_howto_article_first(self):
+        Article.objects.create(
+            article_id="howToArticle",
+            title="使い方記事",
+            tag="howto",
+            post_time=timezone.now() - timedelta(days=1),
+            is_open=True,
+        )
+        response = self.client.get("/articles/")
+        articles = list(response.context["articles"])
+        self.assertEqual(articles[0].article_id, "howToArticle")
+
+    def test_is_pinned_article_false_sorts_by_post_time_only(self):
+        Article.objects.create(
+            article_id="howToArticle",
+            title="使い方記事",
+            tag="howto",
+            post_time=timezone.now() - timedelta(days=1),
+            is_open=True,
+        )
+        self.client.cookies["is_pinned_article"] = "False"
+        response = self.client.get("/articles/")
+        articles = list(response.context["articles"])
+        self.assertEqual(articles[0].article_id, self.article.article_id)
+
+
+class ArticleModelTest(TestCase):
+    """Article.get_top_news_articles() のテスト"""
+
+    def test_news_tag_article_is_included(self):
+        article = Article.objects.create(
+            article_id="news-1", title="ニュース記事", tag="news",
+            post_time=timezone.now(), is_open=True,
+        )
+        self.assertIn(article, Article.get_top_news_articles())
+
+    def test_release_tag_article_is_included(self):
+        article = Article.objects.create(
+            article_id="release-1", title="リリース記事", tag="release",
+            post_time=timezone.now(), is_open=True,
+        )
+        self.assertIn(article, Article.get_top_news_articles())
+
+    def test_handle_as_news_article_is_included_regardless_of_tag(self):
+        article = Article.objects.create(
+            article_id="blog-as-news", title="ニュース扱いブログ", tag="blog",
+            post_time=timezone.now(), is_open=True, handle_as_news=True,
+        )
+        self.assertIn(article, Article.get_top_news_articles())
+
+    def test_other_tag_article_is_excluded(self):
+        article = Article.objects.create(
+            article_id="blog-1", title="通常ブログ", tag="blog",
+            post_time=timezone.now(), is_open=True,
+        )
+        self.assertNotIn(article, Article.get_top_news_articles())
+
+    def test_closed_article_is_excluded(self):
+        article = Article.objects.create(
+            article_id="news-closed", title="非公開ニュース", tag="news",
+            post_time=timezone.now(), is_open=False,
+        )
+        self.assertNotIn(article, Article.get_top_news_articles())
+
+    def test_future_post_time_article_is_excluded(self):
+        article = Article.objects.create(
+            article_id="news-future", title="未来投稿ニュース", tag="news",
+            post_time=timezone.now() + timedelta(days=1), is_open=True,
+        )
+        self.assertNotIn(article, Article.get_top_news_articles())
+
+    def test_limited_to_three_articles(self):
+        for i in range(5):
+            Article.objects.create(
+                article_id=f"news-{i}", title=f"ニュース{i}", tag="news",
+                post_time=timezone.now() - timedelta(days=i), is_open=True,
+            )
+        self.assertEqual(len(Article.get_top_news_articles()), 3)
+
+    def test_ordered_by_post_time_desc(self):
+        older = Article.objects.create(
+            article_id="news-older", title="古いニュース", tag="news",
+            post_time=timezone.now() - timedelta(days=2), is_open=True,
+        )
+        newer = Article.objects.create(
+            article_id="news-newer", title="新しいニュース", tag="news",
+            post_time=timezone.now() - timedelta(days=1), is_open=True,
+        )
+        result = list(Article.get_top_news_articles())
+        self.assertLess(result.index(newer), result.index(older))
 
 
 @override_settings(STATICFILES_STORAGE=STATIC_STORAGE)

--- a/subekashi/tests/TEST_PLAN_INTEGRATION.md
+++ b/subekashi/tests/TEST_PLAN_INTEGRATION.md
@@ -224,6 +224,22 @@
 | 操作 | `POST /contact/` `{category="不具合の報告"}` (`detail` 欠落) |
 | 検証 | HTTP 200、`context["result"]` にエラーメッセージが含まれる |
 
+#### 4-3. 正常な問い合わせ送信時にContactレコードが自動登録される
+
+`Contact.create_contact()` によりお問い合わせ内容がDBに自動登録される（実装は `tests/test_views.py` の `ContactViewTest` に追加済み）。
+
+| 項目 | 内容 |
+| --- | --- |
+| 操作 | `POST /contact/` `{category="不具合の報告", detail="テスト詳細文"}` |
+| 検証 | `Contact.objects.filter(detail="テスト詳細文").exists() == True` |
+
+#### 4-4. 不正入力時はContactレコードが作成されない
+
+| 項目 | 内容 |
+| --- | --- |
+| 操作 | `POST /contact/` `{category="不具合の報告"}` (`detail` 欠落) |
+| 検証 | `Contact.objects.count()` が操作前後で変化しない |
+
 ---
 
 ### 5. 楽曲検索・API フロー

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -71,6 +71,12 @@
 | Googleリダイレクトリンク | `"https://www.google.com/url?q=https://youtu.be/abc1234abcd"` | `"https://youtu.be/abc1234abcd"` |
 | 複数URL | `"https://youtu.be/abc1234abcd,https://x.com/u/1"` | 各URLが正規化されたカンマ区切り |
 
+#### 1-6. `get_allow_media(url)`
+
+| テストケース | 入力 | 期待結果 |
+| --- | --- | --- |
+| Bluesky URL | `https://bsky.app/profile/example.bsky.social` | `result["id"] == "bluesky"` |
+
 ---
 
 ### 2. `lib/song_service.py` — 曲サービス
@@ -508,6 +514,14 @@
 | `url` のユニーク制約 | 同じURLで2件作成 | `IntegrityError` が発生 |
 | 曲との多対多関係 | `link.songs.add(song)` | 関係が成立する |
 
+#### 11-5. `Contact` モデル
+
+| テストケース | 操作 | 期待結果 |
+| --- | --- | --- |
+| `create_contact(detail)` | `Contact.create_contact("内容")` | レコードが作成され `post_time` が今日の日付になる |
+| `get_answered()` | `answer` が空(`None`)のレコード | 結果に含まれない |
+| `get_answered()` | `answer` が設定されたレコード | 結果に含まれる、`-id` 順 |
+
 ---
 
 ### 12. `article` アプリ
@@ -531,6 +545,85 @@
 | 記事タイトルの表示 | 有効なarticle_id | レスポンスにタイトルが含まれる |
 | 存在しない記事ID | 無効なarticle_id | HTTP 404 |
 | 非公開記事 | `is_open=False` | HTTP 404 |
+
+#### 12-3. `is_pinned_article` Cookie による並び替え (`ArticlesView`)
+
+| テストケース | 条件 | 期待結果 |
+| --- | --- | --- |
+| Cookie未指定（デフォルトTrue） | `article_id="howToArticle"` の記事が存在 | 一覧の先頭が `howToArticle` になる |
+| Cookie `is_pinned_article=False` | 同上 | `-post_time` 順のみで並び、`howToArticle` は先頭固定されない |
+
+#### 12-4. `Article.get_top_news_articles()`
+
+| テストケース | 前提条件 | 期待結果 |
+| --- | --- | --- |
+| `tag="news"` の記事 | 公開済み・投稿済み | 結果に含まれる |
+| `tag="release"` の記事 | 公開済み・投稿済み | 結果に含まれる |
+| `handle_as_news=True` の記事 | `tag="blog"` など他タグでも | 結果に含まれる |
+| 上記以外のタグ | `handle_as_news=False` | 結果に含まれない |
+| 非公開記事 | `is_open=False` | 結果に含まれない |
+| 未来の`post_time` | `post_time` が未来日時 | 結果に含まれない |
+| 件数上限 | 該当記事が5件 | 最大3件までに絞られる |
+| 並び順 | 複数の該当記事 | `-post_time` の降順 |
+
+---
+
+### 13. `converters.py` — URLコンバータ
+
+**テストファイル**: `tests/test_converters.py`
+
+#### 13-1. `SQLiteIntConverter`
+
+巨大な整数を含むURLアクセス時にSQLiteのINTEGER範囲を超えて`OverflowError`が発生していた不具合の修正に対応。
+
+| テストケース | 入力 | 期待結果 |
+| --- | --- | --- |
+| 通常の整数 | `"123"` | `123` を返す |
+| SQLite INT最大値 | `str(9223372036854775807)` | そのまま返す |
+| 最大値超過 | `str(9223372036854775808)` | `ValueError` が発生 |
+| 巨大な数値 | `"9" * 30` | `ValueError` が発生 |
+| `/songs/<id>/` への巨大なID | `"9" * 30` | HTTP 404（500エラーにならない） |
+
+---
+
+### 14. `management/commands` — 管理コマンド
+
+**テストファイル**: `tests/test_management_commands.py`
+
+#### 14-1. `delete` コマンド
+
+| テストケース | 条件 | 期待結果 |
+| --- | --- | --- |
+| 通常削除 | `delete <id>` | Songが削除される |
+| デフォルトの挙動 | `delete <id>` | 紐づく`SongLink.is_removed`が`True`になる |
+| `--keep-links` 指定 | `delete <id> --keep-links` | `SongLink.is_removed`は`False`のまま |
+| 存在しないID | `delete 999999` | 例外を投げず警告を出力 |
+
+#### 14-2. `youtube` コマンド
+
+DBロックエラー対策で全件処理時に先にID一覧を取得する方式に変更したことに対応（YouTube APIはモック化）。
+
+| テストケース | 条件 | 期待結果 |
+| --- | --- | --- |
+| `-id` 指定 | 特定のSongのみ対象 | 指定Songのみ`view`等が更新される |
+| `-id` 未指定 | SongLinkが紐づく全Song | 該当する全Songが更新される |
+| SongLinkが無いSong | 対象外 | 更新されない（スキップ） |
+| 全動画が取得不可 | `get_youtube_api` が `{}` を返す | `is_deleted=True` で保存される |
+
+---
+
+### 15. `templatetags/song_card.py` — テンプレートタグ
+
+**テストファイル**: `tests/test_templatetags_song_card.py`
+
+#### 15-1. `get_author(song)`
+
+| テストケース | 条件 | 期待結果 |
+| --- | --- | --- |
+| 作者0人 | `song.authors` が空 | 「作者不明」を表示 |
+| 作者1人 | `song.authors` に1件 | 作者名と作者ページへのリンクを表示 |
+| 作者2人以上 | `song.authors` に2件以上 | 「合作」を表示 |
+| 作者名の特殊文字 | `name="<script>"` | HTMLエスケープされる |
 
 ---
 
@@ -580,7 +673,10 @@ subekashi/tests/
 ├── test_views.py                   # 実装済み: ビュー（GET・POST）
 ├── test_api.py                     # 実装済み: REST API
 ├── test_middleware.py              # 実装済み: ミドルウェア
-└── test_models.py                  # 実装済み: モデル基本動作
+├── test_models.py                  # 実装済み: モデル基本動作
+├── test_converters.py              # 実装済み: URLコンバータ
+├── test_management_commands.py     # 実装済み: 管理コマンド
+└── test_templatetags_song_card.py  # 実装済み: song_card テンプレートタグ
 
 article/
 └── tests.py                        # 実装済み: ArticlesView・DefaultArticleView

--- a/subekashi/tests/test_converters.py
+++ b/subekashi/tests/test_converters.py
@@ -1,0 +1,60 @@
+"""
+SQLiteIntConverter のテスト
+
+巨大な整数を含むURLアクセス時に OverflowError ではなく 404 になることを検証する。
+"""
+from django.test import TestCase, Client, override_settings
+
+from subekashi.converters import SQLiteIntConverter
+from subekashi.models import Song
+
+
+STATIC_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
+
+SQLITE_INT_MAX = 9223372036854775807
+SQLITE_INT_MIN = -9223372036854775808
+
+
+class SQLiteIntConverterTest(TestCase):
+    """SQLiteIntConverter.to_python() のテスト"""
+
+    def setUp(self):
+        self.converter = SQLiteIntConverter()
+
+    def test_normal_value_returns_int(self):
+        self.assertEqual(self.converter.to_python("123"), 123)
+
+    def test_max_value_is_accepted(self):
+        self.assertEqual(self.converter.to_python(str(SQLITE_INT_MAX)), SQLITE_INT_MAX)
+
+    def test_over_max_value_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            self.converter.to_python(str(SQLITE_INT_MAX + 1))
+
+    def test_huge_value_raises_value_error(self):
+        with self.assertRaises(ValueError):
+            self.converter.to_python("9" * 30)
+
+    def test_to_url_returns_str(self):
+        self.assertEqual(self.converter.to_url(123), "123")
+
+
+@override_settings(STATICFILES_STORAGE=STATIC_STORAGE)
+class SQLiteIntConverterUrlTest(TestCase):
+    """巨大な整数を含むURLアクセス時の挙動テスト"""
+
+    def setUp(self):
+        self.client = Client()
+        self.song = Song.objects.create(title="URLテスト曲")
+
+    def test_normal_song_id_returns_200(self):
+        response = self.client.get(f"/songs/{self.song.id}/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_huge_song_id_returns_404(self):
+        response = self.client.get(f"/songs/{SQLITE_INT_MAX + 1}/")
+        self.assertEqual(response.status_code, 404)
+
+    def test_extremely_huge_song_id_returns_404(self):
+        response = self.client.get(f"/songs/{'9' * 30}/")
+        self.assertEqual(response.status_code, 404)

--- a/subekashi/tests/test_lib_url.py
+++ b/subekashi/tests/test_lib_url.py
@@ -205,6 +205,11 @@ class GetAllowMediaTest(SimpleTestCase):
         self.assertIsNot(result, False)
         self.assertEqual(result["id"], "soundcloud")
 
+    def test_bluesky_url_returns_bluesky_media(self):
+        result = get_allow_media("https://bsky.app/profile/example.bsky.social")
+        self.assertIsNot(result, False)
+        self.assertEqual(result["id"], "bluesky")
+
 
 class GetAllMediaTest(SimpleTestCase):
     """get_all_media() のテスト（SEND_DISCORD=False のため外部送信なし）"""

--- a/subekashi/tests/test_management_commands.py
+++ b/subekashi/tests/test_management_commands.py
@@ -1,0 +1,96 @@
+"""
+管理コマンドのテスト
+
+delete: is_removedをfalseのままにする--keep-linksオプションを検証する。
+youtube: DBロック対策で処理方式を変更した後の挙動（id指定・全件処理・リンク無しスキップ・動画削除時の扱い）を検証する。
+"""
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from subekashi.models import Song, SongLink
+
+
+class DeleteCommandTest(TestCase):
+    """delete コマンドのテスト"""
+
+    def setUp(self):
+        self.song = Song.objects.create(title="削除テスト曲")
+        self.link = SongLink.objects.create(url="https://youtu.be/deletetest01")
+        self.link.songs.add(self.song)
+
+    def test_delete_removes_song(self):
+        call_command("delete", str(self.song.id))
+        self.assertFalse(Song.objects.filter(pk=self.song.id).exists())
+
+    def test_delete_sets_links_is_removed_true_by_default(self):
+        call_command("delete", str(self.song.id))
+        self.link.refresh_from_db()
+        self.assertTrue(self.link.is_removed)
+
+    def test_delete_with_keep_links_does_not_set_is_removed(self):
+        call_command("delete", str(self.song.id), "--keep-links")
+        self.link.refresh_from_db()
+        self.assertFalse(self.link.is_removed)
+
+    def test_nonexistent_song_id_does_not_raise(self):
+        # 存在しないIDを指定してもエラーにならないこと
+        call_command("delete", "999999")
+
+
+class YoutubeCommandTest(TestCase):
+    """youtube コマンドのテスト"""
+
+    def setUp(self):
+        self.song1 = Song.objects.create(title="YouTube曲1")
+        self.link1 = SongLink.objects.create(url="https://youtu.be/aaaaaaaaaaa")
+        self.link1.songs.add(self.song1)
+
+        self.song2 = Song.objects.create(title="YouTube曲2")
+        self.link2 = SongLink.objects.create(url="https://youtu.be/bbbbbbbbbbb")
+        self.link2.songs.add(self.song2)
+
+        self.song_without_link = Song.objects.create(title="リンク無し曲")
+
+    @patch("subekashi.management.commands.youtube.sleep")
+    @patch("subekashi.management.commands.youtube.get_youtube_api")
+    def test_id_option_updates_only_that_song(self, mock_api, mock_sleep):
+        mock_api.return_value = {"view": 100, "like": 10, "upload_time": None}
+        call_command("youtube", id=self.song1.id)
+
+        self.song1.refresh_from_db()
+        self.song2.refresh_from_db()
+        self.assertEqual(self.song1.view, 100)
+        self.assertEqual(self.song2.view, None)
+
+    @patch("subekashi.management.commands.youtube.sleep")
+    @patch("subekashi.management.commands.youtube.get_youtube_api")
+    def test_without_id_updates_all_songs_with_links(self, mock_api, mock_sleep):
+        mock_api.return_value = {"view": 50, "like": 5, "upload_time": None}
+        call_command("youtube")
+
+        self.song1.refresh_from_db()
+        self.song2.refresh_from_db()
+        self.assertEqual(self.song1.view, 50)
+        self.assertEqual(self.song2.view, 50)
+
+    @patch("subekashi.management.commands.youtube.sleep")
+    @patch("subekashi.management.commands.youtube.get_youtube_api")
+    def test_song_without_links_is_skipped(self, mock_api, mock_sleep):
+        mock_api.return_value = {"view": 50, "like": 5, "upload_time": None}
+        call_command("youtube")
+
+        self.song_without_link.refresh_from_db()
+        self.assertIsNone(self.song_without_link.view)
+
+    @patch("subekashi.management.commands.youtube.sleep")
+    @patch("subekashi.management.commands.youtube.get_youtube_api")
+    def test_all_videos_unavailable_marks_song_deleted(self, mock_api, mock_sleep):
+        # 動画が削除されている場合、get_youtube_apiは{}を返す
+        mock_api.return_value = {}
+        call_command("youtube", id=self.song1.id)
+
+        self.song1.refresh_from_db()
+        self.assertTrue(self.song1.is_deleted)
+        self.assertEqual(self.song1.view, 0)

--- a/subekashi/tests/test_models.py
+++ b/subekashi/tests/test_models.py
@@ -5,7 +5,8 @@ Song, Author, AuthorAlias, SongLink の CRUD・制約・メソッドを検証す
 """
 from django.db import IntegrityError
 from django.test import TestCase
-from subekashi.models import Author, AuthorAlias, Song, SongLink
+from django.utils import timezone
+from subekashi.models import Author, AuthorAlias, Contact, Song, SongLink
 
 
 class AuthorModelTest(TestCase):
@@ -219,3 +220,42 @@ class SongLinkModelTest(TestCase):
     def test_set_allow_dup_for_nonexistent_url_returns_none(self):
         result = SongLink.set_allow_dup_for_url("https://youtu.be/notexist1234")
         self.assertIsNone(result)
+
+
+class ContactModelTest(TestCase):
+    """Contact モデルのテスト"""
+
+    def test_create_contact_creates_record(self):
+        contact = Contact.create_contact("テスト問い合わせ内容")
+        self.assertIsNotNone(contact.pk)
+        self.assertEqual(contact.detail, "テスト問い合わせ内容")
+
+    def test_create_contact_sets_post_time_to_today(self):
+        contact = Contact.create_contact("テスト問い合わせ内容")
+        self.assertEqual(contact.post_time, timezone.localdate())
+
+    def test_create_contact_answer_is_empty(self):
+        contact = Contact.create_contact("テスト問い合わせ内容")
+        self.assertFalse(contact.answer)
+
+    def test_get_answered_excludes_unanswered(self):
+        Contact.objects.create(detail="未回答", post_time=timezone.localdate())
+        result = Contact.get_answered()
+        self.assertEqual(list(result), [])
+
+    def test_get_answered_includes_answered(self):
+        contact = Contact.objects.create(
+            detail="回答済み", post_time=timezone.localdate(), answer="回答内容"
+        )
+        result = Contact.get_answered()
+        self.assertIn(contact, result)
+
+    def test_get_answered_orders_by_id_desc(self):
+        first = Contact.objects.create(
+            detail="1件目", post_time=timezone.localdate(), answer="回答1"
+        )
+        second = Contact.objects.create(
+            detail="2件目", post_time=timezone.localdate(), answer="回答2"
+        )
+        result = list(Contact.get_answered())
+        self.assertEqual(result, [second, first])

--- a/subekashi/tests/test_templatetags_song_card.py
+++ b/subekashi/tests/test_templatetags_song_card.py
@@ -1,0 +1,45 @@
+"""
+song_card テンプレートタグのテスト
+
+get_author(): 作者0人・1人・2人以上（合作）の表示分岐を検証する。
+SEND_DISCORD=False のためDiscordへの実送信は発生しない。
+"""
+from django.test import TestCase
+from django.urls import reverse
+
+from subekashi.models import Author, Song
+from subekashi.templatetags.song_card import get_author
+
+
+class GetAuthorTest(TestCase):
+    """get_author() のテスト"""
+
+    def test_no_author_returns_unknown_author(self):
+        song = Song.objects.create(title="作者不明曲")
+        result = get_author(song)
+        self.assertIn("作者不明", result)
+
+    def test_single_author_returns_author_link(self):
+        song = Song.objects.create(title="作者ありの曲")
+        author = Author.objects.create(name="テスト作者")
+        song.authors.add(author)
+        result = get_author(song)
+        self.assertIn("テスト作者", result)
+        self.assertIn(reverse("subekashi:author", args=[author.id]), result)
+
+    def test_two_authors_returns_collaboration(self):
+        song = Song.objects.create(title="合作曲")
+        song.authors.add(
+            Author.objects.create(name="作者A"),
+            Author.objects.create(name="作者B"),
+        )
+        result = get_author(song)
+        self.assertIn("合作", result)
+
+    def test_author_name_html_is_escaped(self):
+        song = Song.objects.create(title="特殊文字作者の曲")
+        author = Author.objects.create(name="<script>")
+        song.authors.add(author)
+        result = get_author(song)
+        self.assertNotIn("<script>", result)
+        self.assertIn("&lt;script&gt;", result)

--- a/subekashi/tests/test_views.py
+++ b/subekashi/tests/test_views.py
@@ -6,7 +6,7 @@ ManifestStaticFilesStorage はテストに不要なため StaticFilesStorage に
 """
 from django.test import TestCase, Client, override_settings
 from django.urls import reverse
-from subekashi.models import Ad, Author, Song
+from subekashi.models import Ad, Author, Contact, Song
 
 
 STATIC_STORAGE = "django.contrib.staticfiles.storage.StaticFilesStorage"
@@ -407,6 +407,14 @@ class ContactViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.context["result"], "ok")
 
+    def test_post_valid_form_creates_contact_record(self):
+        # 自動登録によりContactレコードが作成されること
+        self.client.post(
+            reverse("subekashi:contact"),
+            {"category": "不具合の報告", "detail": "テスト詳細文"},
+        )
+        self.assertTrue(Contact.objects.filter(detail="テスト詳細文").exists())
+
     def test_post_invalid_form_returns_error(self):
         # detail が未入力の場合はフォームバリデーションエラー
         response = self.client.post(
@@ -415,6 +423,14 @@ class ContactViewTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertIn("入力必須項目", response.context["result"])
+
+    def test_post_invalid_form_does_not_create_contact_record(self):
+        count_before = Contact.objects.count()
+        self.client.post(
+            reverse("subekashi:contact"),
+            {"category": "不具合の報告"},
+        )
+        self.assertEqual(Contact.objects.count(), count_before)
 
 
 @override_settings(STATICFILES_STORAGE=STATIC_STORAGE)


### PR DESCRIPTION
## Summary
2026/4/11にテストスイートが整備されて以降、Claude Proを未契約だった期間(4月〜8月)にテストなしで追加・修正された箇所を洗い出し、テストを補完しました。

- Contact自動登録 (`Contact.create_contact` / `ContactView`)
- 巨大なintを含むURLアクセス時の`OverflowError`修正の回帰テスト (`SQLiteIntConverter`)
- `Article.get_top_news_articles` / `is_pinned_article` Cookieによる並び替え
- `delete`管理コマンドの`--keep-links`オプション
- `youtube`管理コマンドのDBロック対策リファクタ後の挙動(YouTube APIはモック)
- `get_author`テンプレートタグ(合作・作者不明時の表示・HTMLエスケープ)
- Bluesky許可の検索テスト

`TEST_PLAN_UNIT.md` / `TEST_PLAN_INTEGRATION.md` も該当箇所を更新しています。

なお、2026年8月8日以降(Pro再契約後)の変更は既にテストが揃っていたため対象外としています。

## Test plan
- [x] `python manage.py test subekashi.tests article.tests` (399件、全てパス)

🤖 Generated with [Claude Code](https://claude.com/claude-code)