### PR TITLE
feat: Song検索・フィルターへの別名（双方向）対応

### DIFF
--- a/subekashi/lib/query_filters.py
+++ b/subekashi/lib/query_filters.py
@@ -1,7 +1,24 @@
 from django.db.models import BooleanField, Case, Exists, OuterRef, Q, Value, When
 from subekashi.constants.constants import ALL_MEDIAS
 from subekashi.lib.url import clean_url
-from subekashi.models import Author, SongLink
+from subekashi.models import Author, AuthorAlias, SongLink
+
+# authorの別名（双方向）にマッチするQを返す
+# 正方向: authorに登録された別名がvalueにマッチする
+# 逆方向: nameがauthor.nameと一致する別名を他のauthorが持ち、その別名がvalueにマッチする場合、
+#         name側のauthorも対象にする（#989の双方向解決に対応）
+def filter_by_author_alias(lookup, value):
+    forward_lookup = {f"authors__aliases__name__{lookup}": value}
+    reverse_names = AuthorAlias.objects.filter(**{f"author__name__{lookup}": value}).values("name")
+    return Q(**forward_lookup) | Q(authors__name__in=reverse_names)
+
+# 作者名によるフィルター（別名・双方向を含む、部分一致）
+def filter_by_author(value):
+    return Q(authors__name__icontains=value) | filter_by_author_alias("icontains", value)
+
+# 作者名によるフィルター（別名・双方向を含む、完全一致）
+def filter_by_author_exact(value):
+    return Q(authors__name__exact=value) | filter_by_author_alias("exact", value)
 
 # topやsearchにあるキーワード検索のフィルター
 def filter_by_keyword(keyword):
@@ -9,6 +26,7 @@ def filter_by_keyword(keyword):
     return (
         Q(title__contains=keyword) |
         Q(authors__name__contains=keyword) |
+        filter_by_author_alias("contains", keyword) |
         Q(lyrics__contains=keyword) |
         Q(links__url__icontains=url_keyword)
     )
@@ -25,7 +43,8 @@ def filter_by_imitated(imitated):
 def filter_by_guesser(guesser):
     return (
         Q(title__contains = guesser) |
-        Q(authors__name__contains = guesser)
+        Q(authors__name__contains = guesser) |
+        filter_by_author_alias("contains", guesser)
     )
 
 # メディアの検索に利用するフィルター

--- a/subekashi/lib/song_filterset.py
+++ b/subekashi/lib/song_filterset.py
@@ -9,6 +9,8 @@ from subekashi.lib.query_filters import (
     filter_by_guesser,
     filter_by_mediatypes,
     filter_by_lack,
+    filter_by_author,
+    filter_by_author_exact,
 )
 from subekashi.lib.url import clean_url
 from subekashi.lib.query_utils import has_view_filter_or_sort, has_like_filter_or_sort, has_upload_time_sort
@@ -49,8 +51,7 @@ class SongFilter(django_filters.FilterSet):
         validators=[validate_max_length(500)]
     )
     author = django_filters.CharFilter(
-        field_name='authors__name',
-        lookup_expr='icontains',
+        method='filter_author',
         validators=[validate_max_length(500)]
     )
     lyrics = django_filters.CharFilter(
@@ -69,8 +70,7 @@ class SongFilter(django_filters.FilterSet):
         validators=[validate_max_length(500)]
     )
     author_exact = django_filters.CharFilter(
-        field_name='authors__name',
-        lookup_expr='exact',
+        method='filter_author_exact',
         validators=[validate_max_length(500)]
     )
 
@@ -139,6 +139,14 @@ class SongFilter(django_filters.FilterSet):
     def filter_keyword(self, queryset, name, value):
         """複数フィールドにわたるキーワード検索"""
         return queryset.filter(filter_by_keyword(value))
+
+    def filter_author(self, queryset, name, value):
+        """作者名によるフィルタ（別名・双方向を含む部分一致）"""
+        return queryset.filter(filter_by_author(value))
+
+    def filter_author_exact(self, queryset, name, value):
+        """作者名によるフィルタ（別名・双方向を含む完全一致）"""
+        return queryset.filter(filter_by_author_exact(value))
 
     def filter_url(self, queryset, name, value):
         """SongLinkテーブルのURLによるフィルタ（clean_urlを適用し部分一致）"""

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -162,6 +162,25 @@
 | 歌詞部分一致 | キーワードが歌詞に含まれる | その曲が結果に含まれる |
 | URL部分一致 | キーワードがURLに含まれる | その曲が結果に含まれる |
 | 一致なし | 存在しないキーワード | 空のクエリセット |
+| 別名（正方向）一致 | `author(foo)` の別名が `foo_sub`、`Author(foo_sub)` が別途存在。keyword=`foo_sub` | `foo` の曲・`foo_sub` の曲の両方が結果に含まれる |
+| 別名（逆方向）一致 | 上記と同じ前提。keyword=`foo` | 双方向解決により `foo` の曲・`foo_sub` の曲の両方が結果に含まれる |
+| 対象authorが存在しない別名 | `author` の別名が `single_alias`（`Author(single_alias)` は未登録） | keyword=`single_alias` で正方向のみヒットする |
+
+#### 3-1-1. `filter_by_author(value)` / `filter_by_author_exact(value)`（`filter_by_author_alias`経由の別名・双方向対応）
+
+| テストケース | 前提条件 | 期待結果 |
+| --- | --- | --- |
+| 作者名の部分一致 | `authors__name`に一致 | 結果に含まれる |
+| 別名（正方向）の部分一致 | `filter_by_keyword`と同様の`foo`/`foo_sub`構成 | `foo`・`foo_sub`双方の曲が結果に含まれる |
+| 部分文字列一致 | 作者名・別名の一部分のみ指定 | `icontains`として双方の曲が結果に含まれる |
+| 完全一致（`_exact`） | 部分文字列のみ指定 | 一致せず結果に含まれない |
+| 完全一致（`_exact`、別名逆方向） | `author.name`に完全一致する値を指定 | 双方向解決により別名先の曲も結果に含まれる |
+
+#### 3-1-2. `filter_by_guesser(guesser)`（別名・双方向対応の追加分）
+
+| テストケース | 前提条件 | 期待結果 |
+| --- | --- | --- |
+| 別名（正方向・逆方向）一致 | `filter_by_keyword`と同様の`foo`/`foo_sub`構成 | 正方向・逆方向いずれの検索語でも双方の曲が結果に含まれる |
 
 #### 3-2. `filter_by_lack()`
 
@@ -474,6 +493,18 @@
 | keyword + sort=-id | `{"keyword": "...", "sort": "-id"}` | ID降順で返される |
 | title + sort=title | `{"title": "...", "sort": "title"}` | タイトル昇順で返される |
 | title + sort=-title | `{"title": "...", "sort": "-title"}` | タイトル降順で返される |
+
+#### 10-3. author/author_exact/keywordフィルターの別名（双方向）対応
+
+`author(foo)` に別名 `foo_sub`（`Author(foo_sub)` も別途存在）を登録したシナリオで、
+`song_search()` 経由でも双方向解決が機能することを確認する。
+
+| テストケース | 入力 | 期待結果 |
+| --- | --- | --- |
+| author（正方向） | `{"author": "foo_sub"}` | `foo`・`foo_sub`双方の曲がヒット |
+| author（逆方向） | `{"author": "foo"}` | `foo`・`foo_sub`双方の曲がヒット |
+| author_exact（逆方向） | `{"author_exact": "foo"}` | `foo`・`foo_sub`双方の曲がヒット |
+| keyword（逆方向） | `{"keyword": "foo"}` | `foo`・`foo_sub`双方の曲がヒット |
 
 ---
 

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -162,17 +162,21 @@
 | 歌詞部分一致 | キーワードが歌詞に含まれる | その曲が結果に含まれる |
 | URL部分一致 | キーワードがURLに含まれる | その曲が結果に含まれる |
 | 一致なし | 存在しないキーワード | 空のクエリセット |
-| 別名（正方向）一致 | `author(foo)` の別名が `foo_sub`、`Author(foo_sub)` が別途存在。keyword=`foo_sub` | `foo` の曲・`foo_sub` の曲の両方が結果に含まれる |
-| 別名（逆方向）一致 | 上記と同じ前提。keyword=`foo` | 双方向解決により `foo` の曲・`foo_sub` の曲の両方が結果に含まれる |
+| 別名（正方向）一致 | `author(yamada)` の別名が `sasaki`、`Author(sasaki)` が別途存在。keyword=`sasaki` | `yamada` の曲・`sasaki` の曲の両方が結果に含まれる |
+| 別名（逆方向）一致 | 上記と同じ前提。keyword=`yamada` | 双方向解決により `yamada` の曲・`sasaki` の曲の両方が結果に含まれる |
 | 対象authorが存在しない別名 | `author` の別名が `single_alias`（`Author(single_alias)` は未登録） | keyword=`single_alias` で正方向のみヒットする |
+
+`yamada`/`sasaki`のように、owner名とtarget名が互いの部分文字列にならない組み合わせを使う。
+`foo`/`foo_sub`のような包含関係だと、素の作者名一致（`icontains`/`contains`）だけで
+逆方向テストが偶然パスしてしまい、別名解決コードを経由したかどうかを検証できないため。
 
 #### 3-1-1. `filter_by_author(value)` / `filter_by_author_exact(value)`（`filter_by_author_alias`経由の別名・双方向対応）
 
 | テストケース | 前提条件 | 期待結果 |
 | --- | --- | --- |
 | 作者名の部分一致 | `authors__name`に一致 | 結果に含まれる |
-| 別名（正方向）の部分一致 | `filter_by_keyword`と同様の`foo`/`foo_sub`構成 | `foo`・`foo_sub`双方の曲が結果に含まれる |
-| 部分文字列一致 | 作者名・別名の一部分のみ指定 | `icontains`として双方の曲が結果に含まれる |
+| 別名（正方向）の部分一致 | `filter_by_keyword`と同様の`yamada`/`sasaki`構成、keyword=`sasaki` | `yamada`・`sasaki`双方の曲が結果に含まれる |
+| 別名（逆方向）の部分一致 | 上記と同じ前提、keyword=`yamada` | `yamada`・`sasaki`双方の曲が結果に含まれる |
 | 完全一致（`_exact`） | 部分文字列のみ指定 | 一致せず結果に含まれない |
 | 完全一致（`_exact`、別名逆方向） | `author.name`に完全一致する値を指定 | 双方向解決により別名先の曲も結果に含まれる |
 
@@ -180,7 +184,7 @@
 
 | テストケース | 前提条件 | 期待結果 |
 | --- | --- | --- |
-| 別名（正方向・逆方向）一致 | `filter_by_keyword`と同様の`foo`/`foo_sub`構成 | 正方向・逆方向いずれの検索語でも双方の曲が結果に含まれる |
+| 別名（正方向・逆方向）一致 | `filter_by_keyword`と同様の`yamada`/`sasaki`構成 | 正方向・逆方向いずれの検索語でも双方の曲が結果に含まれる |
 
 #### 3-2. `filter_by_lack()`
 
@@ -496,15 +500,17 @@
 
 #### 10-3. author/author_exact/keywordフィルターの別名（双方向）対応
 
-`author(foo)` に別名 `foo_sub`（`Author(foo_sub)` も別途存在）を登録したシナリオで、
-`song_search()` 経由でも双方向解決が機能することを確認する。
+`author(yamada)` に別名 `sasaki`（`Author(sasaki)` も別途存在）を登録したシナリオで、
+`song_search()` 経由でも双方向解決が機能することを確認する。owner名(`yamada`)とtarget名
+(`sasaki`)は互いの部分文字列にならない組み合わせを使い、素の作者名一致だけで
+逆方向テストが偶然パスしないようにしている。
 
 | テストケース | 入力 | 期待結果 |
 | --- | --- | --- |
-| author（正方向） | `{"author": "foo_sub"}` | `foo`・`foo_sub`双方の曲がヒット |
-| author（逆方向） | `{"author": "foo"}` | `foo`・`foo_sub`双方の曲がヒット |
-| author_exact（逆方向） | `{"author_exact": "foo"}` | `foo`・`foo_sub`双方の曲がヒット |
-| keyword（逆方向） | `{"keyword": "foo"}` | `foo`・`foo_sub`双方の曲がヒット |
+| author（正方向） | `{"author": "sasaki"}` | `yamada`・`sasaki`双方の曲がヒット |
+| author（逆方向） | `{"author": "yamada"}` | `yamada`・`sasaki`双方の曲がヒット |
+| author_exact（逆方向） | `{"author_exact": "yamada"}` | `yamada`・`sasaki`双方の曲がヒット |
+| keyword（逆方向） | `{"keyword": "yamada"}` | `yamada`・`sasaki`双方の曲がヒット |
 
 ---
 

--- a/subekashi/tests/test_lib_query_filters.py
+++ b/subekashi/tests/test_lib_query_filters.py
@@ -57,32 +57,39 @@ class FilterByKeywordTest(TestCase):
 class FilterByKeywordAuthorAliasTest(TestCase):
     """filter_by_keyword() の別名（双方向）対応のテスト
 
-    issue #969本文のシナリオ:
-    1. Song1 (author: foo) 追加
-    2. Song2 (author: foo_sub) 追加
-    3. fooに別名foo_subを追加
-    4. keyword=foo_subで検索 → Song1, Song2がヒットすること
-    5. keyword=fooで検索 → 双方向のためSong1, Song2の双方がヒットすること
+    issue #969本文のシナリオ（foo/foo_sub）に準じるが、owner/targetの名前は
+    互いに部分文字列関係にならないものを使う。foo/foo_subのように片方がもう
+    片方を含む名前だと、icontains/containsによる素の作者名一致
+    (Q(authors__name__contains=keyword)) だけでテストが通ってしまい、
+    別名解決コードを経由したかどうかを検証できないため。
+
+    1. Song1 (author: yamada) 追加
+    2. Song2 (author: sasaki) 追加
+    3. yamadaに別名sasakiを追加（sasakiという名前のAuthorも別途実在する）
+    4. keyword=sasakiで検索 → Song1, Song2がヒットすること（正方向）
+    5. keyword=yamadaで検索 → 双方向のためSong1, Song2の双方がヒットすること（逆方向）
     """
 
     def setUp(self):
-        self.foo = Author.objects.create(name="foo")
-        self.foo_sub = Author.objects.create(name="foo_sub")
+        self.owner = Author.objects.create(name="yamada")
+        self.target = Author.objects.create(name="sasaki")
         self.song1 = Song.objects.create(title="Song1")
-        self.song1.authors.add(self.foo)
+        self.song1.authors.add(self.owner)
         self.song2 = Song.objects.create(title="Song2")
-        self.song2.authors.add(self.foo_sub)
-        AuthorAlias.objects.create(name="foo_sub", author=self.foo, alias_type="past")
+        self.song2.authors.add(self.target)
+        AuthorAlias.objects.create(name="sasaki", author=self.owner, alias_type="past")
 
     def test_forward_alias_name_matches_owning_authors_songs(self):
-        # 正方向: keyword=foo_sub はfooの別名にマッチするためSong1もヒットする
-        qs = Song.objects.filter(filter_by_keyword("foo_sub")).distinct()
+        # 正方向: keyword=sasakiはyamadaの別名にマッチするためSong1もヒットする
+        qs = Song.objects.filter(filter_by_keyword("sasaki")).distinct()
         self.assertIn(self.song1, qs)
         self.assertIn(self.song2, qs)
 
     def test_reverse_alias_matches_target_authors_own_songs(self):
-        # 逆方向: keyword=foo はfoo_subの逆方向別名にもなるためSong2もヒットする
-        qs = Song.objects.filter(filter_by_keyword("foo")).distinct()
+        # 逆方向: keyword=yamadaはsasaki自身の名前とは無関係な文字列であり、
+        # 素の作者名一致(authors__name__contains)ではSong2はヒットしない。
+        # 別名解決コードの逆方向ロジックによってのみSong2がヒットする。
+        qs = Song.objects.filter(filter_by_keyword("yamada")).distinct()
         self.assertIn(self.song1, qs)
         self.assertIn(self.song2, qs)
 
@@ -153,49 +160,54 @@ class FilterByGuesserTest(TestCase):
         self.assertIn(self.song_by_author, qs)
 
     def test_filter_by_author_alias_bidirectional(self):
-        foo = Author.objects.create(name="推測foo")
-        foo_sub = Author.objects.create(name="推測foo_sub")
-        song_foo = Song.objects.create(title="推測foo曲")
-        song_foo.authors.add(foo)
-        song_foo_sub = Song.objects.create(title="推測foo_sub曲")
-        song_foo_sub.authors.add(foo_sub)
-        AuthorAlias.objects.create(name="推測foo_sub", author=foo, alias_type="past")
+        # owner/targetの名前は部分文字列関係にならないものを使う（素の作者名一致で
+        # 偶然パスしてしまい、別名解決コードを経由したか検証できなくなるのを防ぐため）
+        owner = Author.objects.create(name="推測ヤマダ")
+        target = Author.objects.create(name="推測ササキ")
+        song_owner = Song.objects.create(title="推測ヤマダ曲")
+        song_owner.authors.add(owner)
+        song_target = Song.objects.create(title="推測ササキ曲")
+        song_target.authors.add(target)
+        AuthorAlias.objects.create(name="推測ササキ", author=owner, alias_type="past")
 
         # 正方向
-        qs = Song.objects.filter(filter_by_guesser("推測foo_sub")).distinct()
-        self.assertIn(song_foo, qs)
-        self.assertIn(song_foo_sub, qs)
+        qs = Song.objects.filter(filter_by_guesser("推測ササキ")).distinct()
+        self.assertIn(song_owner, qs)
+        self.assertIn(song_target, qs)
 
-        # 逆方向
-        qs = Song.objects.filter(filter_by_guesser("推測foo")).distinct()
-        self.assertIn(song_foo, qs)
-        self.assertIn(song_foo_sub, qs)
+        # 逆方向: "推測ヤマダ"は"推測ササキ"の部分文字列ではないため、
+        # 別名解決コードの逆方向ロジックがなければsong_targetはヒットしない
+        qs = Song.objects.filter(filter_by_guesser("推測ヤマダ")).distinct()
+        self.assertIn(song_owner, qs)
+        self.assertIn(song_target, qs)
 
 
 class FilterByAuthorTest(TestCase):
-    """filter_by_author() のテスト（別名・双方向の部分一致）"""
+    """filter_by_author() のテスト（別名・双方向の部分一致）
+
+    owner/targetの名前は部分文字列関係にならないものを使う（素の作者名一致
+    Q(authors__name__icontains=value) で偶然パスしてしまうのを防ぐため）
+    """
 
     def setUp(self):
-        self.foo = Author.objects.create(name="afoo")
-        self.foo_sub = Author.objects.create(name="afoo_sub")
+        self.owner = Author.objects.create(name="ayamada")
+        self.target = Author.objects.create(name="asasaki")
         self.song1 = Song.objects.create(title="AuthorSong1")
-        self.song1.authors.add(self.foo)
+        self.song1.authors.add(self.owner)
         self.song2 = Song.objects.create(title="AuthorSong2")
-        self.song2.authors.add(self.foo_sub)
-        AuthorAlias.objects.create(name="afoo_sub", author=self.foo, alias_type="past")
-
-    def test_matches_own_author_name(self):
-        qs = Song.objects.filter(filter_by_author("afoo")).distinct()
-        self.assertIn(self.song1, qs)
-        self.assertIn(self.song2, qs)
+        self.song2.authors.add(self.target)
+        AuthorAlias.objects.create(name="asasaki", author=self.owner, alias_type="past")
 
     def test_matches_forward_alias(self):
-        qs = Song.objects.filter(filter_by_author("afoo_sub")).distinct()
+        # 正方向: "asasaki"はownerの別名にマッチするためSong1もヒットする
+        qs = Song.objects.filter(filter_by_author("asasaki")).distinct()
         self.assertIn(self.song1, qs)
         self.assertIn(self.song2, qs)
 
-    def test_partial_match(self):
-        qs = Song.objects.filter(filter_by_author("afo")).distinct()
+    def test_matches_reverse_alias(self):
+        # 逆方向: "ayamada"はtarget("asasaki")の部分文字列ではないため、
+        # 別名解決コードの逆方向ロジックがなければSong2はヒットしない
+        qs = Song.objects.filter(filter_by_author("ayamada")).distinct()
         self.assertIn(self.song1, qs)
         self.assertIn(self.song2, qs)
 

--- a/subekashi/tests/test_lib_query_filters.py
+++ b/subekashi/tests/test_lib_query_filters.py
@@ -4,7 +4,7 @@ lib/query_filters.py のテスト
 楽曲検索フィルター関数の Q オブジェクト生成・適用結果を検証する。
 """
 from django.test import TestCase
-from subekashi.models import Author, Song, SongLink
+from subekashi.models import Author, AuthorAlias, Song, SongLink
 from subekashi.lib.query_filters import (
     filter_by_keyword,
     filter_by_imitate,
@@ -12,6 +12,8 @@ from subekashi.lib.query_filters import (
     filter_by_guesser,
     filter_by_lack,
     filter_by_mediatypes,
+    filter_by_author,
+    filter_by_author_exact,
     make_is_lack_annotation,
 )
 
@@ -50,6 +52,50 @@ class FilterByKeywordTest(TestCase):
     def test_no_match_returns_empty(self):
         qs = Song.objects.filter(filter_by_keyword("存在しないキーワードXYZ999"))
         self.assertEqual(qs.count(), 0)
+
+
+class FilterByKeywordAuthorAliasTest(TestCase):
+    """filter_by_keyword() の別名（双方向）対応のテスト
+
+    issue #969本文のシナリオ:
+    1. Song1 (author: foo) 追加
+    2. Song2 (author: foo_sub) 追加
+    3. fooに別名foo_subを追加
+    4. keyword=foo_subで検索 → Song1, Song2がヒットすること
+    5. keyword=fooで検索 → 双方向のためSong1, Song2の双方がヒットすること
+    """
+
+    def setUp(self):
+        self.foo = Author.objects.create(name="foo")
+        self.foo_sub = Author.objects.create(name="foo_sub")
+        self.song1 = Song.objects.create(title="Song1")
+        self.song1.authors.add(self.foo)
+        self.song2 = Song.objects.create(title="Song2")
+        self.song2.authors.add(self.foo_sub)
+        AuthorAlias.objects.create(name="foo_sub", author=self.foo, alias_type="past")
+
+    def test_forward_alias_name_matches_owning_authors_songs(self):
+        # 正方向: keyword=foo_sub はfooの別名にマッチするためSong1もヒットする
+        qs = Song.objects.filter(filter_by_keyword("foo_sub")).distinct()
+        self.assertIn(self.song1, qs)
+        self.assertIn(self.song2, qs)
+
+    def test_reverse_alias_matches_target_authors_own_songs(self):
+        # 逆方向: keyword=foo はfoo_subの逆方向別名にもなるためSong2もヒットする
+        qs = Song.objects.filter(filter_by_keyword("foo")).distinct()
+        self.assertIn(self.song1, qs)
+        self.assertIn(self.song2, qs)
+
+    def test_unidirectional_when_target_author_not_registered(self):
+        # 対象authorがまだ存在しない別名は単方向のまま、別名のnameを検索すればヒットする
+        Author.objects.create(name="single")
+        single_song = Song.objects.create(title="SingleSong")
+        author = Author.objects.get(name="single")
+        single_song.authors.add(author)
+        AuthorAlias.objects.create(name="single_alias", author=author, alias_type="spell")
+
+        qs = Song.objects.filter(filter_by_keyword("single_alias")).distinct()
+        self.assertIn(single_song, qs)
 
 
 class FilterByImitateTest(TestCase):
@@ -105,6 +151,81 @@ class FilterByGuesserTest(TestCase):
     def test_filter_by_author_name(self):
         qs = Song.objects.filter(filter_by_guesser("推測テスト作者")).distinct()
         self.assertIn(self.song_by_author, qs)
+
+    def test_filter_by_author_alias_bidirectional(self):
+        foo = Author.objects.create(name="推測foo")
+        foo_sub = Author.objects.create(name="推測foo_sub")
+        song_foo = Song.objects.create(title="推測foo曲")
+        song_foo.authors.add(foo)
+        song_foo_sub = Song.objects.create(title="推測foo_sub曲")
+        song_foo_sub.authors.add(foo_sub)
+        AuthorAlias.objects.create(name="推測foo_sub", author=foo, alias_type="past")
+
+        # 正方向
+        qs = Song.objects.filter(filter_by_guesser("推測foo_sub")).distinct()
+        self.assertIn(song_foo, qs)
+        self.assertIn(song_foo_sub, qs)
+
+        # 逆方向
+        qs = Song.objects.filter(filter_by_guesser("推測foo")).distinct()
+        self.assertIn(song_foo, qs)
+        self.assertIn(song_foo_sub, qs)
+
+
+class FilterByAuthorTest(TestCase):
+    """filter_by_author() のテスト（別名・双方向の部分一致）"""
+
+    def setUp(self):
+        self.foo = Author.objects.create(name="afoo")
+        self.foo_sub = Author.objects.create(name="afoo_sub")
+        self.song1 = Song.objects.create(title="AuthorSong1")
+        self.song1.authors.add(self.foo)
+        self.song2 = Song.objects.create(title="AuthorSong2")
+        self.song2.authors.add(self.foo_sub)
+        AuthorAlias.objects.create(name="afoo_sub", author=self.foo, alias_type="past")
+
+    def test_matches_own_author_name(self):
+        qs = Song.objects.filter(filter_by_author("afoo")).distinct()
+        self.assertIn(self.song1, qs)
+        self.assertIn(self.song2, qs)
+
+    def test_matches_forward_alias(self):
+        qs = Song.objects.filter(filter_by_author("afoo_sub")).distinct()
+        self.assertIn(self.song1, qs)
+        self.assertIn(self.song2, qs)
+
+    def test_partial_match(self):
+        qs = Song.objects.filter(filter_by_author("afo")).distinct()
+        self.assertIn(self.song1, qs)
+        self.assertIn(self.song2, qs)
+
+
+class FilterByAuthorExactTest(TestCase):
+    """filter_by_author_exact() のテスト（別名・双方向の完全一致）"""
+
+    def setUp(self):
+        self.foo = Author.objects.create(name="efoo")
+        self.foo_sub = Author.objects.create(name="efoo_sub")
+        self.song1 = Song.objects.create(title="ExactSong1")
+        self.song1.authors.add(self.foo)
+        self.song2 = Song.objects.create(title="ExactSong2")
+        self.song2.authors.add(self.foo_sub)
+        AuthorAlias.objects.create(name="efoo_sub", author=self.foo, alias_type="past")
+
+    def test_exact_match_does_not_match_partial(self):
+        qs = Song.objects.filter(filter_by_author_exact("efo")).distinct()
+        self.assertNotIn(self.song1, qs)
+        self.assertNotIn(self.song2, qs)
+
+    def test_exact_match_own_name(self):
+        qs = Song.objects.filter(filter_by_author_exact("efoo")).distinct()
+        self.assertIn(self.song1, qs)
+        self.assertIn(self.song2, qs)
+
+    def test_exact_match_forward_alias(self):
+        qs = Song.objects.filter(filter_by_author_exact("efoo_sub")).distinct()
+        self.assertIn(self.song1, qs)
+        self.assertIn(self.song2, qs)
 
 
 class FilterByLackTest(TestCase):

--- a/subekashi/tests/test_lib_song_search.py
+++ b/subekashi/tests/test_lib_song_search.py
@@ -212,41 +212,46 @@ class SongSearchSortWithAuthorFilterTest(TestCase):
 class SongSearchAuthorAliasBidirectionalTest(TestCase):
     """author/author_exact/keywordフィルターの別名（双方向）対応の結合テスト
 
-    issue #969本文のシナリオをsong_search()経由で検証する
+    issue #969本文のシナリオ（foo/foo_sub）に準じるが、owner/targetの名前は
+    互いに部分文字列関係にならないものを使う。片方がもう片方を含む名前だと、
+    素の作者名一致（icontains/contains）だけで逆方向テストが偶然パスしてしまい、
+    別名解決コードを経由したかどうかを検証できないため。
     """
 
     def setUp(self):
-        self.foo = Author.objects.create(name="検索foo")
-        self.foo_sub = Author.objects.create(name="検索foo_sub")
+        self.owner = Author.objects.create(name="検索ヤマダ")
+        self.target = Author.objects.create(name="検索ササキ")
         self.song1 = Song.objects.create(title="検索Song1")
-        self.song1.authors.add(self.foo)
+        self.song1.authors.add(self.owner)
         self.song2 = Song.objects.create(title="検索Song2")
-        self.song2.authors.add(self.foo_sub)
-        AuthorAlias.objects.create(name="検索foo_sub", author=self.foo, alias_type="past")
+        self.song2.authors.add(self.target)
+        AuthorAlias.objects.create(name="検索ササキ", author=self.owner, alias_type="past")
 
     def test_author_filter_forward_alias_matches_both_songs(self):
-        qs, stats = song_search({"author": "検索foo_sub", "size": "100"})
+        qs, stats = song_search({"author": "検索ササキ", "size": "100"})
         titles = {s.title for s in qs}
         self.assertEqual(stats["count"], 2)
         self.assertIn("検索Song1", titles)
         self.assertIn("検索Song2", titles)
 
     def test_author_filter_reverse_alias_matches_both_songs(self):
-        qs, stats = song_search({"author": "検索foo", "size": "100"})
+        # "検索ヤマダ"は"検索ササキ"の部分文字列ではないため、逆方向ロジックが
+        # なければ検索Song2はヒットしない
+        qs, stats = song_search({"author": "検索ヤマダ", "size": "100"})
         titles = {s.title for s in qs}
         self.assertEqual(stats["count"], 2)
         self.assertIn("検索Song1", titles)
         self.assertIn("検索Song2", titles)
 
     def test_author_exact_reverse_alias_matches_both_songs(self):
-        qs, stats = song_search({"author_exact": "検索foo", "size": "100"})
+        qs, stats = song_search({"author_exact": "検索ヤマダ", "size": "100"})
         titles = {s.title for s in qs}
         self.assertEqual(stats["count"], 2)
         self.assertIn("検索Song1", titles)
         self.assertIn("検索Song2", titles)
 
     def test_keyword_filter_reverse_alias_matches_both_songs(self):
-        qs, stats = song_search({"keyword": "検索foo", "size": "100"})
+        qs, stats = song_search({"keyword": "検索ヤマダ", "size": "100"})
         titles = {s.title for s in qs}
         self.assertEqual(stats["count"], 2)
         self.assertIn("検索Song1", titles)

--- a/subekashi/tests/test_lib_song_search.py
+++ b/subekashi/tests/test_lib_song_search.py
@@ -7,7 +7,7 @@ import math
 from datetime import datetime, timezone
 from django.test import TestCase
 from rest_framework.exceptions import ValidationError
-from subekashi.models import Author, Song, SongLink
+from subekashi.models import Author, AuthorAlias, Song, SongLink
 from subekashi.lib.song_search import song_search, DEFAULT_SIZE
 
 
@@ -207,6 +207,50 @@ class SongSearchSortWithAuthorFilterTest(TestCase):
         qs, _ = song_search({"author": "共通作者", "sort": "-title", "size": "100"})
         titles = [s.title for s in qs]
         self.assertEqual(titles, ["Ccc曲", "Bbb曲", "Aaa曲"])
+
+
+class SongSearchAuthorAliasBidirectionalTest(TestCase):
+    """author/author_exact/keywordフィルターの別名（双方向）対応の結合テスト
+
+    issue #969本文のシナリオをsong_search()経由で検証する
+    """
+
+    def setUp(self):
+        self.foo = Author.objects.create(name="検索foo")
+        self.foo_sub = Author.objects.create(name="検索foo_sub")
+        self.song1 = Song.objects.create(title="検索Song1")
+        self.song1.authors.add(self.foo)
+        self.song2 = Song.objects.create(title="検索Song2")
+        self.song2.authors.add(self.foo_sub)
+        AuthorAlias.objects.create(name="検索foo_sub", author=self.foo, alias_type="past")
+
+    def test_author_filter_forward_alias_matches_both_songs(self):
+        qs, stats = song_search({"author": "検索foo_sub", "size": "100"})
+        titles = {s.title for s in qs}
+        self.assertEqual(stats["count"], 2)
+        self.assertIn("検索Song1", titles)
+        self.assertIn("検索Song2", titles)
+
+    def test_author_filter_reverse_alias_matches_both_songs(self):
+        qs, stats = song_search({"author": "検索foo", "size": "100"})
+        titles = {s.title for s in qs}
+        self.assertEqual(stats["count"], 2)
+        self.assertIn("検索Song1", titles)
+        self.assertIn("検索Song2", titles)
+
+    def test_author_exact_reverse_alias_matches_both_songs(self):
+        qs, stats = song_search({"author_exact": "検索foo", "size": "100"})
+        titles = {s.title for s in qs}
+        self.assertEqual(stats["count"], 2)
+        self.assertIn("検索Song1", titles)
+        self.assertIn("検索Song2", titles)
+
+    def test_keyword_filter_reverse_alias_matches_both_songs(self):
+        qs, stats = song_search({"keyword": "検索foo", "size": "100"})
+        titles = {s.title for s in qs}
+        self.assertEqual(stats["count"], 2)
+        self.assertIn("検索Song1", titles)
+        self.assertIn("検索Song2", titles)
 
 
 class SongSearchValidationErrorTest(TestCase):


### PR DESCRIPTION
## 概要
#969 の子issue #990 の実装です。#989 の双方向解決ロジックを利用します。

「Songのfilterでもauthorも参照して別名でもfilterするようにする」という仕様に対応し、`filter_by_keyword` / `filter_by_guesser` / `SongFilter.author` / `SongFilter.author_exact` が作者の別名（正方向・逆方向）にもマッチするようにしました。

## 変更内容
- `subekashi/lib/query_filters.py`
  - `filter_by_author_alias(lookup, value)`: 別名の双方向解決を行う共通ヘルパーを追加
    - 正方向: `authors__aliases__name` がvalueにマッチ
    - 逆方向: nameがauthorのnameと一致する別名を持つ他authorのnameがvalueにマッチする場合、そのauthorも対象にする
  - `filter_by_author(value)` / `filter_by_author_exact(value)` を新規追加
  - `filter_by_keyword` / `filter_by_guesser` に別名マッチを追加
- `subekashi/lib/song_filterset.py`
  - `author` / `author_exact` を `field_name` 方式から `method` 方式に変更し、新しいフィルター関数を利用
  - 既存の `NEED_DISTINCT_KEY_LIST` によるdistinct処理は変更なしでカバーされることを確認

## 確認シナリオ（issue #969 本文より）
1. Song1 (author: foo) 追加
2. Song2 (author: foo_sub) 追加
3. authors/foo に別名 foo_sub を追加
4. keyword/author=foo_sub で検索 → Song1, Song2 がヒット（正方向）
5. keyword/author/author_exact=foo で検索 → Song1, Song2 がヒット（逆方向・双方向）

## テスト
- [x] `subekashi/tests/test_lib_query_filters.py` に別名・双方向のケースを追加
- [x] `subekashi/tests/test_lib_song_search.py` に `song_search()` 経由の結合テストを追加
- [x] `python manage.py test subekashi.tests article.tests` (418件 OK)
- [x] `TEST_PLAN_UNIT.md` 更新

closes #990