### PR TITLE
feat: 別名一覧・登録画面のUI改善と検索フィルターの調整

### DIFF
--- a/subekashi/lib/query_filters.py
+++ b/subekashi/lib/query_filters.py
@@ -3,14 +3,28 @@ from subekashi.constants.constants import ALL_MEDIAS
 from subekashi.lib.url import clean_url
 from subekashi.models import Author, AuthorAlias, SongLink
 
+# alias_type="another"（別名義）は同一人物が運用していても意図的に区別して扱うべきものであり、
+# 検索時に自動的に同一視されると意図しない結果になるため双方向解決の対象外とする（#996）
+NON_ANOTHER_ALIAS_TYPES = [value for value, _ in AuthorAlias.CHOICES if value != "another"]
+
 # authorの別名（双方向）にマッチするQを返す
 # 正方向: authorに登録された別名がvalueにマッチする
 # 逆方向: nameがauthor.nameと一致する別名を他のauthorが持ち、その別名がvalueにマッチする場合、
 #         name側のauthorも対象にする（#989の双方向解決に対応）
 def filter_by_author_alias(lookup, value):
-    forward_lookup = {f"authors__aliases__name__{lookup}": value}
-    reverse_names = AuthorAlias.objects.filter(**{f"author__name__{lookup}": value}).values("name")
-    return Q(**forward_lookup) | Q(authors__name__in=reverse_names)
+    # name一致とalias_type制限を同一dictにまとめることで、複数aliasを持つauthorに対しても
+    # 同一のAuthorAlias行に対して両条件が適用されるようにする
+    # （否定条件(~Q)をANDすると多対多の行スコープが崩れるため、alias_type__inの正方向条件を使う）
+    forward_condition = Q(**{
+        f"authors__aliases__name__{lookup}": value,
+        "authors__aliases__alias_type__in": NON_ANOTHER_ALIAS_TYPES,
+    })
+    reverse_names = (
+        AuthorAlias.objects.exclude(alias_type="another")
+        .filter(**{f"author__name__{lookup}": value})
+        .values("name")
+    )
+    return forward_condition | Q(authors__name__in=reverse_names)
 
 # 作者名によるフィルター（別名・双方向を含む、部分一致）
 def filter_by_author(value):

--- a/subekashi/models/author.py
+++ b/subekashi/models/author.py
@@ -46,7 +46,8 @@ class AuthorLink(models.Model):
 
 
 # 曲の作者の別の呼び方の情報
-# 曲の登録時や編集時に正式な呼び方(author.name)に変更するために使用される
+# nameがauthor.nameに対して双方向に別名をつける（Author.get_effective_aliases()参照）。
+# 曲の検索(subekashi/lib/query_filters.py)やAuthorの別名一覧画面で利用される
 class AuthorAlias(models.Model):
     CHOICES = (
         ("id", "ID"),

--- a/subekashi/static/subekashi/css/author_aliases.css
+++ b/subekashi/static/subekashi/css/author_aliases.css
@@ -38,6 +38,28 @@
     text-align: center;
 }
 
+.dummybutton i {
+    margin-right: 10px;
+    font-size: 1.0em;
+}
+
+/* アイコンとテキストを上下中央寄せにする（共通のp{padding-top:5px}を打ち消す） */
+.dummybuttons .dummybutton {
+    align-items: center;
+}
+
+.dummybuttons .dummybutton p {
+    padding-top: 0;
+}
+
+.alias-type-description {
+    margin: 10px 0;
+}
+
+.alias-type-description i {
+    margin-right: 8px;
+}
+
 /* delete画面: フォームを.dummybuttons内の他要素と並べるため、フォーム自体のボックスを消す */
 .dummybutton-form {
     display: contents;

--- a/subekashi/static/subekashi/js/author_alias_form.js
+++ b/subekashi/static/subekashi/js/author_alias_form.js
@@ -1,0 +1,26 @@
+window.addEventListener('DOMContentLoaded', () => {
+    const form = document.querySelector('form');
+    const submitButton = form.querySelector('input[type="submit"]');
+    const aliasTypeSelect = document.getElementById('alias_type');
+    const descriptionEl = document.getElementById('alias-type-description-text');
+    const descriptionIconEl = document.getElementById('alias-type-description-icon');
+
+    function updateSubmitState() {
+        submitButton.disabled = !form.checkValidity();
+    }
+
+    function updateAliasTypeDescription() {
+        const selected = aliasTypeSelect.selectedOptions[0];
+        const description = selected ? (selected.dataset.description || '') : '';
+        descriptionEl.textContent = description;
+        // 「選択してください」（value=""）の間はアイコンも非表示にする
+        descriptionIconEl.style.display = description ? '' : 'none';
+    }
+
+    form.addEventListener('input', updateSubmitState);
+    form.addEventListener('change', updateSubmitState);
+    aliasTypeSelect.addEventListener('change', updateAliasTypeDescription);
+
+    updateSubmitState();
+    updateAliasTypeDescription();
+});

--- a/subekashi/templates/subekashi/author_alias_delete.html
+++ b/subekashi/templates/subekashi/author_alias_delete.html
@@ -10,10 +10,10 @@
     <p>この別名を削除します。よろしいですか？</p>
     <div class="dummybuttons">
         <a href="{% url 'subekashi:author_aliases' author.id %}">
-            <div class="dummybutton black-dummybutton"><p>キャンセル</p></div>
+            <div class="dummybutton black-dummybutton"><i class="fas fa-times"></i><p>キャンセル</p></div>
         </a>
         <form action="{% url 'subekashi:author_alias_delete' author.id alias.id %}" method="POST" class="dummybutton-form">{% csrf_token %}
-            <button type="submit" class="dummybutton black-dummybutton"><p>削除する</p></button>
+            <button type="submit" class="dummybutton black-dummybutton"><i class="far fa-trash-alt"></i><p>削除する</p></button>
         </form>
     </div>
 </section>

--- a/subekashi/templates/subekashi/author_alias_edit.html
+++ b/subekashi/templates/subekashi/author_alias_edit.html
@@ -15,17 +15,22 @@
         <div class="form-col">
             <label for="alias_type">種別</label>
             <select id="alias_type" name="alias_type" required>
-                {% for value, label in alias_type_choices %}
-                    <option value="{{ value }}" {% if value == alias.alias_type %}selected{% endif %}>{{ label }}</option>
+                <option value="" disabled>選択してください</option>
+                {% for choice in alias_type_choices %}
+                    <option value="{{ choice.value }}" data-description="{{ choice.description }}" {% if choice.value == alias.alias_type %}selected{% endif %}>{{ choice.label }}</option>
                 {% endfor %}
             </select>
         </div>
+        <p id="alias-type-description" class="alias-type-description info">
+            <i id="alias-type-description-icon" class="fas fa-info-circle info"></i><span id="alias-type-description-text"></span>
+        </p>
         <input type="submit" value="更新">
     </form>
 </section>
 {% endblock %}
 
 {% block js %}
+<script src="{% static 'subekashi/js/author_alias_form.js' %}" defer></script>
 <script defer>
     {% if error %}
         showToast("error", "{{ error }}");

--- a/subekashi/templates/subekashi/author_alias_new.html
+++ b/subekashi/templates/subekashi/author_alias_new.html
@@ -15,17 +15,22 @@
         <div class="form-col">
             <label for="alias_type">種別</label>
             <select id="alias_type" name="alias_type" required>
-                {% for value, label in alias_type_choices %}
-                    <option value="{{ value }}">{{ label }}</option>
+                <option value="" selected disabled>選択してください</option>
+                {% for choice in alias_type_choices %}
+                    <option value="{{ choice.value }}" data-description="{{ choice.description }}">{{ choice.label }}</option>
                 {% endfor %}
             </select>
         </div>
-        <input type="submit" value="登録">
+        <p id="alias-type-description" class="alias-type-description info">
+            <i id="alias-type-description-icon" class="fas fa-info-circle info"></i><span id="alias-type-description-text"></span>
+        </p>
+        <input type="submit" value="登録" disabled>
     </form>
 </section>
 {% endblock %}
 
 {% block js %}
+<script src="{% static 'subekashi/js/author_alias_form.js' %}" defer></script>
 <script defer>
     {% if error %}
         showToast("error", "{{ error }}");

--- a/subekashi/templates/subekashi/author_aliases.html
+++ b/subekashi/templates/subekashi/author_aliases.html
@@ -8,8 +8,11 @@
 <section>
     <h1>{{ author.name }}の別名一覧</h1>
     <div class="dummybuttons">
+        <a onclick="reloadPage()">
+            <div class="dummybutton black-dummybutton"><i class="fas fa-redo"></i><p>再読み込み</p></div>
+        </a>
         <a href="{% url 'subekashi:author_alias_new' author.id %}">
-            <div class="dummybutton black-dummybutton"><p>別名を追加する</p></div>
+            <div class="dummybutton black-dummybutton"><i class="fas fa-plus"></i><p>別名を追加する</p></div>
         </a>
     </div>
 
@@ -38,6 +41,14 @@
 
 {% block js %}
 <script defer>
+    // historyを更新するリロード（subekashi/js/editor.jsと同様。DOMContentLoaded時に
+    // <details>要素の存在を前提とする処理を含むため、editor.js自体は読み込まない）
+    function reloadPage() {
+        const newUrl = location.pathname + '?reload=' + Date.now();
+        history.replaceState(null, '', newUrl);
+        location.reload();
+    }
+
     {% if request.GET.toast == "new" %}
         showToast("ok", "別名を追加しました。");
     {% elif request.GET.toast == "edit" %}

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -186,6 +186,17 @@
 | --- | --- | --- |
 | 別名（正方向・逆方向）一致 | `filter_by_keyword`と同様の`yamada`/`sasaki`構成 | 正方向・逆方向いずれの検索語でも双方の曲が結果に含まれる |
 
+#### 3-1-3. `alias_type="another"`（別名義）の除外（#996）
+
+`another`は同一人物が運用していても意図的に区別して扱うべきものであり、双方向解決（検索）の対象外とする。
+`filter_by_author` / `filter_by_author_exact` / `filter_by_keyword` / `filter_by_guesser` すべてに共通の挙動。
+
+| テストケース | 前提条件 | 期待結果 |
+| --- | --- | --- |
+| 正方向・`alias_type=another` | ownerの別名(`alias_type="another"`)のnameで検索 | ownerの曲は結果に含まれない（target自身の曲のみヒット） |
+| 逆方向・`alias_type=another` | owner自身のnameで検索 | target側の曲は結果に含まれない |
+| 同一ownerに`another`以外の別名も存在 | `another`の別名と`past`の別名を両方持つowner | `past`側の別名名での検索は通常通りヒットする（`another`の存在に影響されない） |
+
 #### 3-2. `filter_by_lack()`
 
 | テストケース | 前提条件 | 期待結果 |
@@ -430,6 +441,8 @@ DBアクセス（重複チェック）を伴うため `TestCase` を使用する
 | `alias_type=past`かつ対象authorが実在 | 別名nameと同名のAuthorが存在 | `channel/<name>/`へのリンクが含まれる |
 | `alias_type=past`だが対象authorが不在 | 別名nameと同名のAuthorが存在しない | `channel/<name>/`へのリンクが含まれない |
 | `alias_type`がpast/another以外 | 例: `abbr`。対象authorは実在 | `channel/<name>/`へのリンクが含まれない |
+| 再読み込みボタン (#996) | 正常アクセス | `reloadPage()`呼び出しと`fa-redo`アイコンが含まれる |
+| 追加ボタンのアイコン (#996) | 正常アクセス | `fa-plus`アイコンが含まれる |
 
 #### 7-8-2. `AuthorAliasNewView` (`/authors/<id>/aliases/new`)（#992）
 
@@ -444,6 +457,10 @@ DBアクセス（重複チェック）を伴うため `TestCase` を使用する
 | Discord通知 | 正常なPOST | `send_discord()`がNEW_DISCORD_URL宛に、別名名・作者名を含む内容で呼ばれる |
 | Discord通知失敗 | `send_discord()`が`False`を返す | HTTP 500、作成したAuthorAliasはロールバック（削除）される |
 | TOCTOU（重複チェックのすり抜け） | `AuthorAliasForm.clean_name`をモックして重複チェックをバイパスし、既存nameでPOST | DB制約(IntegrityError)を捕捉し、HTTP 200のままフォームエラー表示（500にならない）。レコードは重複作成されない |
+| `alias_type`のプレースホルダー (#996) | GETリクエスト | `<option value="" selected disabled>選択してください</option>`が含まれる |
+| `alias_type`の説明属性 (#996) | GETリクエスト | 各`<option>`に`data-description`属性が付与されている |
+| 登録ボタンの初期状態 (#996) | GETリクエスト | `<input type="submit" ... disabled>`（フォームがinvalidな状態で初期表示される） |
+| author_alias_form.jsの読み込み (#996) | GETリクエスト | スクリプトタグが含まれる |
 
 #### 7-8-3. `AuthorAliasEditView` (`/authors/<id>/aliases/<alias_id>/edit`)（#992）
 
@@ -460,6 +477,9 @@ DBアクセス（重複チェック）を伴うため `TestCase` を使用する
 | Discord通知 | 実質的な変更があるPOST | `send_discord()`がNEW_DISCORD_URL宛に、変更後の内容を含む形で呼ばれる |
 | Discord通知失敗 | 変更ありのPOSTで`send_discord()`が`False`を返す | HTTP 500 |
 | TOCTOU（重複チェックのすり抜け） | `AuthorAliasForm.clean_name`をモックして重複チェックをバイパスし、既存nameでPOST | DB制約(IntegrityError)を捕捉し、HTTP 200のままフォームエラー表示（500にならない）。更新前の値のまま維持される |
+| 現在のalias_typeが選択済み (#996) | GETリクエスト | 該当する`<option>`に`selected`が付与されている |
+| `alias_type`のプレースホルダー (#996) | GETリクエスト | `<option value="" disabled>選択してください</option>`が含まれる（selectedではない） |
+| author_alias_form.jsの読み込み (#996) | GETリクエスト | スクリプトタグが含まれる |
 
 #### 7-8-4. `AuthorAliasDeleteView` (`/authors/<id>/aliases/<alias_id>/delete`)（#992）
 
@@ -471,6 +491,7 @@ DBアクセス（重複チェック）を伴うため `TestCase` を使用する
 | 正常なPOST | 上記 | `History.create_for_author()`が呼ばれ、`history_type="delete"`、`history.author`は削除後も維持される |
 | Discord通知 | 正常なPOST | `send_discord()`がNEW_DISCORD_URL宛に、削除対象の別名名を含む内容で呼ばれる（新規・編集と同じ通知先） |
 | Discord通知失敗 | `send_discord()`が`False`を返す | HTTP 500。AuthorAliasは削除されず、Historyも作成されない（通知できた場合のみ実削除する設計） |
+| キャンセル・削除ボタンのアイコン (#996) | GETリクエスト | `fa-times`・`fa-trash-alt`アイコンが含まれる |
 
 #### 7-9. `ChannelView` (`/channel/<name>/`)
 

--- a/subekashi/tests/test_lib_query_filters.py
+++ b/subekashi/tests/test_lib_query_filters.py
@@ -240,6 +240,54 @@ class FilterByAuthorExactTest(TestCase):
         self.assertIn(self.song2, qs)
 
 
+class FilterByAuthorAliasAnotherTypeExcludedTest(TestCase):
+    """alias_type="another"（別名義）は検索フィルターの別名解決対象から除外されることのテスト（#996）
+
+    別名義は同一人物の表記揺れ・旧名等とは異なり、意図的に区別して扱うべきものの
+    ため、双方向解決（filter_by_author_alias）の対象外とする。
+    """
+
+    def setUp(self):
+        self.owner = Author.objects.create(name="another_yamada")
+        self.target = Author.objects.create(name="another_sasaki")
+        self.song1 = Song.objects.create(title="AnotherSong1")
+        self.song1.authors.add(self.owner)
+        self.song2 = Song.objects.create(title="AnotherSong2")
+        self.song2.authors.add(self.target)
+        AuthorAlias.objects.create(name="another_sasaki", author=self.owner, alias_type="another")
+
+    def test_filter_by_author_forward_excludes_another(self):
+        qs = Song.objects.filter(filter_by_author("another_sasaki")).distinct()
+        self.assertNotIn(self.song1, qs)
+        self.assertIn(self.song2, qs)
+
+    def test_filter_by_author_reverse_excludes_another(self):
+        qs = Song.objects.filter(filter_by_author("another_yamada")).distinct()
+        self.assertIn(self.song1, qs)
+        self.assertNotIn(self.song2, qs)
+
+    def test_filter_by_author_exact_excludes_another(self):
+        qs = Song.objects.filter(filter_by_author_exact("another_sasaki")).distinct()
+        self.assertNotIn(self.song1, qs)
+        self.assertIn(self.song2, qs)
+
+    def test_filter_by_keyword_excludes_another(self):
+        qs = Song.objects.filter(filter_by_keyword("another_sasaki")).distinct()
+        self.assertNotIn(self.song1, qs)
+        self.assertIn(self.song2, qs)
+
+    def test_filter_by_guesser_excludes_another(self):
+        qs = Song.objects.filter(filter_by_guesser("another_sasaki")).distinct()
+        self.assertNotIn(self.song1, qs)
+        self.assertIn(self.song2, qs)
+
+    def test_non_another_type_still_matches(self):
+        # 同じownerに別名義以外(past)の別名も追加した場合、そちらは通常通りヒットする
+        AuthorAlias.objects.create(name="another_yamada_past", author=self.owner, alias_type="past")
+        qs = Song.objects.filter(filter_by_author("another_yamada_past")).distinct()
+        self.assertIn(self.song1, qs)
+
+
 class FilterByLackTest(TestCase):
     """filter_by_lack() のテスト
 

--- a/subekashi/tests/test_views.py
+++ b/subekashi/tests/test_views.py
@@ -461,6 +461,15 @@ class AuthorAliasesViewTest(TestCase):
 
         self.assertNotContains(response, reverse("subekashi:channel", args=["略称対象作者"]))
 
+    def test_reload_button_present(self):
+        response = self.client.get(reverse("subekashi:author_aliases", args=[self.author.id]))
+        self.assertContains(response, "reloadPage()")
+        self.assertContains(response, "fa-redo")
+
+    def test_add_button_has_plus_icon(self):
+        response = self.client.get(reverse("subekashi:author_aliases", args=[self.author.id]))
+        self.assertContains(response, "fa-plus")
+
 
 @override_settings(STATICFILES_STORAGE=STATIC_STORAGE)
 class AuthorAliasNewViewTest(TestCase):
@@ -477,6 +486,45 @@ class AuthorAliasNewViewTest(TestCase):
     def test_nonexistent_author_returns_404(self):
         response = self.client.get(reverse("subekashi:author_alias_new", args=[99999]))
         self.assertEqual(response.status_code, 404)
+
+    def test_alias_type_has_placeholder_option(self):
+        response = self.client.get(reverse("subekashi:author_alias_new", args=[self.author.id]))
+        self.assertContains(response, '<option value="" selected disabled>選択してください</option>')
+
+    def test_alias_type_options_have_description_attribute(self):
+        response = self.client.get(reverse("subekashi:author_alias_new", args=[self.author.id]))
+        self.assertContains(response, 'data-description="以前使用されていた名称です。')
+
+    def test_linkable_alias_types_mention_channel_link_in_description(self):
+        # past/anotherはchannelリンクが貼られる種別のため、説明文にその旨を含める
+        response = self.client.get(reverse("subekashi:author_alias_new", args=[self.author.id]))
+        content = response.content.decode()
+        past_option = content[content.index('value="past"'):content.index('</option>', content.index('value="past"'))]
+        another_option = content[content.index('value="another"'):content.index('</option>', content.index('value="another"'))]
+        abbr_option = content[content.index('value="abbr"'):content.index('</option>', content.index('value="abbr"'))]
+        self.assertIn("チャンネルページへのリンク", past_option)
+        self.assertIn("チャンネルページへのリンク", another_option)
+        self.assertNotIn("チャンネルページへのリンク", abbr_option)
+
+    def test_submit_button_initially_disabled(self):
+        response = self.client.get(reverse("subekashi:author_alias_new", args=[self.author.id]))
+        self.assertContains(response, '<input type="submit" value="登録" disabled>')
+
+    def test_alias_type_description_has_info_icon_between_form_and_button(self):
+        response = self.client.get(reverse("subekashi:author_alias_new", args=[self.author.id]))
+        content = response.content.decode()
+        self.assertContains(response, "fas fa-info-circle info")
+        self.assertContains(response, 'id="alias-type-description-text"')
+        # 説明欄がフォームのフィールド群より後、送信ボタンより前にあることを確認する
+        description_index = content.index('id="alias-type-description"')
+        select_index = content.index('id="alias_type"')
+        submit_index = content.index('<input type="submit"')
+        self.assertLess(select_index, description_index)
+        self.assertLess(description_index, submit_index)
+
+    def test_includes_author_alias_form_js(self):
+        response = self.client.get(reverse("subekashi:author_alias_new", args=[self.author.id]))
+        self.assertContains(response, "author_alias_form.js")
 
     def test_post_creates_alias_and_redirects_to_list(self):
         response = self.client.post(
@@ -565,6 +613,25 @@ class AuthorAliasEditViewTest(TestCase):
             reverse("subekashi:author_alias_edit", args=[self.author.id, self.alias.id])
         )
         self.assertEqual(response.status_code, 200)
+
+    def test_current_alias_type_is_selected(self):
+        response = self.client.get(
+            reverse("subekashi:author_alias_edit", args=[self.author.id, self.alias.id])
+        )
+        self.assertContains(response, 'value="past" data-description="以前使用されていた名称です。')
+        self.assertContains(response, 'selected>以前の名称</option>')
+
+    def test_alias_type_has_disabled_placeholder_option(self):
+        response = self.client.get(
+            reverse("subekashi:author_alias_edit", args=[self.author.id, self.alias.id])
+        )
+        self.assertContains(response, '<option value="" disabled>選択してください</option>')
+
+    def test_includes_author_alias_form_js(self):
+        response = self.client.get(
+            reverse("subekashi:author_alias_edit", args=[self.author.id, self.alias.id])
+        )
+        self.assertContains(response, "author_alias_form.js")
 
     def test_nonexistent_alias_returns_404(self):
         response = self.client.get(
@@ -689,6 +756,13 @@ class AuthorAliasDeleteViewTest(TestCase):
         )
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "削除対象別名")
+
+    def test_cancel_and_delete_buttons_have_icons(self):
+        response = self.client.get(
+            reverse("subekashi:author_alias_delete", args=[self.author.id, self.alias.id])
+        )
+        self.assertContains(response, "fa-times")
+        self.assertContains(response, "fa-trash-alt")
 
     def test_nonexistent_alias_returns_404(self):
         response = self.client.get(

--- a/subekashi/views/author_alias.py
+++ b/subekashi/views/author_alias.py
@@ -17,6 +17,26 @@ from subekashi.lib.author_alias_service import (
 LINKABLE_ALIAS_TYPES = ("past", "another")
 DUPLICATE_NAME_ERROR = "その別名は既に登録されています。"
 
+CHANNEL_LINK_NOTE = "対応する名義が存在する場合、一覧画面でチャンネルページへのリンクが表示されます。"
+
+ALIAS_TYPE_DESCRIPTIONS = {
+    "id": "YouTubeチャンネルIDなど、名前ではなく識別子としての別名です。",
+    "abbr": "作者名を短縮した略称です。",
+    "common": "正式名称ではないが、広く使われている呼び方です。",
+    "past": f"以前使用されていた名称です。{CHANNEL_LINK_NOTE}",
+    "sns": "SNS上で使われている名称です。",
+    "spell": "表記揺れ（ひらがな・カタカナ・英字表記の違いなど）です。",
+    "another": f"同一人物が運用している別名義です。曲検索では自動的に同一視されません。{CHANNEL_LINK_NOTE}",
+}
+
+
+def alias_type_choices():
+    """new/edit画面のalias_typeフォーム用の選択肢（各選択肢の説明文付き）を返す"""
+    return [
+        {"value": value, "label": label, "description": ALIAS_TYPE_DESCRIPTIONS.get(value, "")}
+        for value, label in AuthorAlias.CHOICES
+    ]
+
 
 class AuthorAliasesView(View):
     def get(self, request, author_id):
@@ -63,7 +83,7 @@ class AuthorAliasNewView(View):
         return {
             "metatitle": f"{self.author.name}の別名を追加",
             "author": self.author,
-            "alias_type_choices": AuthorAlias.CHOICES,
+            "alias_type_choices": alias_type_choices(),
         }
 
     def get(self, request, author_id):
@@ -122,7 +142,7 @@ class AuthorAliasEditView(View):
             "metatitle": f"{self.author.name}の別名『{self.alias.name}』を編集",
             "author": self.author,
             "alias": self.alias,
-            "alias_type_choices": AuthorAlias.CHOICES,
+            "alias_type_choices": alias_type_choices(),
         }
 
     def get(self, request, author_id, alias_id):


### PR DESCRIPTION
## 概要
#969 の子issue #996 の実装です。

当初 #996 は「曲登録・編集時に別名を正式名称(author.name)へ正規化する」という内容で起票していましたが、検討の結果**この仕様は実装しないことになりました**。理由: 別名は検索(#990)・別名一覧画面(#992)で十分に活用されており、曲登録フォームの入力値を暗黙的に別名で正規化する挙動はユーザーにとって分かりにくく、影響範囲（掲載拒否リストの判定含む）も大きいため見送りました。そのためissueのタイトル・説明を差し替え、別名CRUD画面（#992）のUI改善・検索フィルターの調整をまとめて扱っています。

`subekashi/models/author.py` の `AuthorAlias` にあった「曲の登録時や編集時に正式な呼び方(author.name)に変更するために使用される」という古いコメント（未実装のまま残っていたもの）も実態に合わせて更新しました。

## 変更内容

### UI改善（`authors/<id>/aliases` list・new/edit画面）
- list画面の「別名を追加する」ボタンの左に再読み込みボタンを追加（`editor.js`の`reloadPage()`と同様のロジックをページ固有に定義）
- 「別名を追加する」/「キャンセル」/「削除する」ボタンにFontAwesomeアイコンを追加
- FontAwesomeアイコンとテキストが上下中央寄せになるようCSSを調整
- new/edit画面に、選択中の`alias_type`の簡単な説明を表示（フォームフィールドと送信ボタンの間、infoアイコン付き、既存の`.info`スタイルを流用）
  - `past`/`another`の説明にはチャンネルリンクが貼られる旨も記載
  - 未選択（プレースホルダー）時はアイコンごと非表示
- `alias_type`フォームに「選択してください」プレースホルダーを追加（値は空でinvalid・required）
- フォームがinvalidな間は登録・更新ボタンをdisabledにする（`author_alias_form.js`を新規追加）

### 検索フィルターの調整（#990）
- `alias_type="another"`（別名義）は、同一人物が運用していても意図的に区別して扱うべきものとして、Song検索フィルター（`filter_by_keyword` / `filter_by_guesser` / `SongFilter.author` / `author_exact`）の別名解決（双方向）の対象から除外
  - 実装メモ: 否定条件(`~Q`)を多対多関係にANDすると行スコープが崩れる（同一のAuthorAlias行に対して両条件が適用されない）ため、`alias_type__in`による正方向条件を同一dictにまとめて同一行に適用されるようにしています

## テスト
- [x] `test_lib_query_filters.py`: `alias_type="another"`が検索フィルターから除外されることを確認するテストを追加
- [x] `test_views.py`: UI変更（アイコン・プレースホルダー・disabled初期状態・説明文の位置）のテストを追加
- [x] `python manage.py test subekashi.tests article.tests` (500件 OK)
- [x] 実サーバーでの動作確認（プレースホルダー・説明文・アイコン表示・検索フィルター除外）
- [x] `TEST_PLAN_UNIT.md` 更新

closes #996