### PR TITLE
fix: 曲詳細ページのタグリンクで検索保存設定cookieが上書きされる問題を修正

### DIFF
--- a/subekashi/static/subekashi/js/songs.js
+++ b/subekashi/static/subekashi/js/songs.js
@@ -48,14 +48,21 @@ function restoreFormValuesFromCookies() {
         return;
     }
 
+    // URLクエリで明示的に指定されている項目は、そちらを優先しcookieでの上書きは行わない
+    const urlParams = new URLSearchParams(window.location.search);
+
     const cookieFormMappings = [
         { cookieName: 'search_isdetail', elementId: 'isdetail', isDetailsElement: true },
-        { cookieName: 'search_songrange', elementId: 'songrange' },
-        { cookieName: 'search_jokerange', elementId: 'jokerange' },
-        { cookieName: 'search_sort', elementId: 'sort' }
+        { cookieName: 'search_songrange', elementId: 'songrange', queryKeys: ['songrange', 'is_subeana'] },
+        { cookieName: 'search_jokerange', elementId: 'jokerange', queryKeys: ['jokerange', 'is_joke'] },
+        { cookieName: 'search_sort', elementId: 'sort', queryKeys: ['sort'] }
     ];
 
-    cookieFormMappings.forEach(({ cookieName, elementId, isDetailsElement }) => {
+    cookieFormMappings.forEach(({ cookieName, elementId, isDetailsElement, queryKeys }) => {
+        if (queryKeys && queryKeys.some((key) => urlParams.has(key))) {
+            return;
+        }
+
         const cookieValue = cookies[cookieName];
         if (cookieValue) {
             const element = document.getElementById(elementId);

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -370,6 +370,9 @@ DBアクセス（重複チェック）を伴うため `TestCase` を使用する
 | is_joke=on | `?is_joke=on` | context["jokerange"] = "on" |
 | is_original/is_inst 大文字True | `?is_original=True` など | 対応 context フィールドが True |
 | is_questionable 大文字True | `?is_questionable=True` | context["is_questionable"] = True |
+| is_subeana経由の絞り込み(タグリンク等)は保存設定cookieを上書きしない | `is_saved_select=on`, `search_songrange=subeana` (cookie), `?is_subeana=xx` | context["songrange"] = "xx"（表示のみ反映）、`search_songrange` cookieは上書きされない |
+| is_joke経由の絞り込み(タグリンク等)は保存設定cookieを上書きしない | `is_saved_select=on`, `search_jokerange=on` (cookie), `?is_joke=only` | context["jokerange"] = "only"（表示のみ反映）、`search_jokerange` cookieは上書きされない |
+| songrangeクエリ(検索フォーム経由)は引き続きcookieに保存される | `is_saved_select=on`, `?songrange=xx` | `search_songrange` cookieに "xx" が保存される |
 
 #### 7-3. `SongView` (`/songs/<id>/`)
 

--- a/subekashi/tests/test_views.py
+++ b/subekashi/tests/test_views.py
@@ -112,6 +112,31 @@ class SongsViewTest(TestCase):
                 self.assertEqual(response.status_code, 200)
                 self.assertTrue(response.context[field])
 
+    def test_is_subeana_query_param_does_not_overwrite_saved_songrange_cookie(self):
+        """曲詳細ページのタグリンク(is_subeana)経由の絞り込みでsearch_songrange cookieが上書きされないこと"""
+        self.client.cookies["is_saved_select"] = "on"
+        self.client.cookies["search_songrange"] = "subeana"
+        response = self.client.get(reverse("subekashi:songs"), {"is_subeana": "xx"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["songrange"], "xx")
+        self.assertNotIn("search_songrange", response.cookies)
+
+    def test_is_joke_query_param_does_not_overwrite_saved_jokerange_cookie(self):
+        """曲詳細ページのタグリンク(is_joke)経由の絞り込みでsearch_jokerange cookieが上書きされないこと"""
+        self.client.cookies["is_saved_select"] = "on"
+        self.client.cookies["search_jokerange"] = "on"
+        response = self.client.get(reverse("subekashi:songs"), {"is_joke": "only"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["jokerange"], "only")
+        self.assertNotIn("search_jokerange", response.cookies)
+
+    def test_songrange_query_param_still_saves_cookie(self):
+        """検索フォーム経由(songrange)の変更は引き続きcookieに保存されること"""
+        self.client.cookies["is_saved_select"] = "on"
+        response = self.client.get(reverse("subekashi:songs"), {"songrange": "xx"})
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.cookies["search_songrange"].value, "xx")
+
 
 @override_settings(STATICFILES_STORAGE=STATIC_STORAGE)
 class SongViewTest(TestCase):

--- a/subekashi/views/songs.py
+++ b/subekashi/views/songs.py
@@ -80,11 +80,11 @@ class SongsView(View):
             if raw is None:
                 continue
             value_lower = raw.lower()
+            # is_subeana/is_joke は曲詳細ページのタグリンク等からの一時的な絞り込み用パラメータのため、
+            # その表示にのみ反映し、検索の保存設定(cookie)は上書きしない
             if filter == "is_subeana":
                 songrange_value = "subeana" if value_lower in ["true", "1"] else "xx"
                 context["songrange"] = songrange_value
-                if is_saved_select == 'on':
-                    cookies_to_set["search_songrange"] = songrange_value
             elif filter == "is_joke":
                 if value_lower in ["true", "1", "only"]:
                     jokerange_value = "only"
@@ -93,8 +93,6 @@ class SongsView(View):
                 else:
                     jokerange_value = "off"
                 context["jokerange"] = jokerange_value
-                if is_saved_select == 'on':
-                    cookies_to_set["search_jokerange"] = jokerange_value
             else:
                 context[filter] = value_lower in ["true", "1"]
 


### PR DESCRIPTION
## 概要

曲詳細ページのタグリンク（例: `?is_subeana=xx`）経由で `/songs/` に遷移すると、検索フォームで保存していた「界隈曲の種類」等の設定が、ユーザーの意図なくcookieに上書き保存されてしまう不具合を修正。

## 原因

- `SongsView._handle`（`subekashi/views/songs.py`）が、`is_subeana`/`is_joke` のようなタグリンク用の一時的な絞り込みクエリを受け取ると、`is_saved_select`がONの場合に無条件で `search_songrange`/`search_jokerange` cookieを上書き保存していた。
- さらにクライアント側の `restoreFormValuesFromCookies()`（`songs.js`）が、ページ読み込み時に無条件でcookieの値をフォームへ復元していたため、URLクエリで明示的に指定した絞り込み（タグリンク由来）が保存済みcookie値で上書きされ、選択肢が正しく切り替わらなくなっていた。

## 変更内容

- `subekashi/views/songs.py`: `BOOL_FORMS` の `is_subeana`/`is_joke` 処理から、cookieへの書き込みを削除。ページ表示のみに反映する。
- `subekashi/static/subekashi/js/songs.js`: `restoreFormValuesFromCookies()` にて、URLクエリで明示的に指定されている項目（`songrange`/`is_subeana`、`jokerange`/`is_joke`、`sort`）はcookie復元をスキップし、URLクエリの指定を優先するように修正。
- `subekashi/tests/test_views.py`: 上記挙動を検証するテストを追加。
- `subekashi/tests/TEST_PLAN_UNIT.md`: 追加したテストケースを記載。

Fixes #1011

## Test plan

- [x] `python manage.py test subekashi.tests article.tests` — 503件全て成功
- [ ] ブラウザでの動作確認（曲詳細ページのタグリンクから `/songs/` へ遷移し、界隈曲の種類・ネタ曲の選択肢が意図通り切り替わり、保存済み設定が上書きされないこと）

🤖 Generated with [Claude Code](https://claude.com/claude-code)