### PR TITLE
feat: 別名の推移的関係解決ロジックの実装（#1005）

### DIFF
--- a/subekashi/models/author.py
+++ b/subekashi/models/author.py
@@ -1,6 +1,10 @@
+from collections import deque
 from dataclasses import dataclass
 from django.db import models
 from .base import GetOrNoneMixin
+
+# 中継点（2ホップ目以降の推移探索）として使わないalias_type（Author.get_transitive_aliases()参照）
+NON_BRIDGING_ALIAS_TYPES = ("another", "group")
 
 
 # 曲の作者の情報
@@ -38,6 +42,57 @@ class Author(GetOrNoneMixin, models.Model):
         ]
         return forward + reverse
 
+    def get_transitive_aliases(self):
+        """推移的な関係解決を含む別名一覧を返す（#1005）
+
+        直接の関係（1ホップ、正方向・逆方向とも）はalias_typeを問わず必ず含む。
+        alias_typeが"another"（別名義）・"group"（グループ）の関係は、そこから先の
+        推移（2ホップ目以降の中継点）には使わない。それ以外の種別（id/abbr/common/
+        past/sns/spell）は中継点として使え、そちら経由でさらに先のノードを発見する。
+
+        循環（A-B-Aのような閉路）が発生しても、訪問済みノード（名前）を記録して
+        無限ループ・重複を防ぐ。
+
+        訪問するノード数に比例してクエリが発行される（各ノードごとに正方向・逆方向で
+        最大2クエリ、中継可能な場合はさらにAuthor検索が1クエリ発行される）ため、
+        巨大なクラスタに対して呼び出すとコストが大きくなる点に注意すること。
+        """
+        def edges_from(name, author):
+            edges = []
+            if author is not None:
+                edges += [
+                    (alias.name, alias.alias_type, alias, False)
+                    for alias in author.aliases.all()
+                ]
+            edges += [
+                (alias.author.name, alias.alias_type, alias, True)
+                for alias in AuthorAlias.objects.filter(name=name).exclude(author=author).select_related("author")
+            ]
+            return edges
+
+        visited_names = {self.name}
+        results = []
+        queue = deque([(self.name, self)])
+
+        while queue:
+            current_name, current_author = queue.popleft()
+            is_direct = current_name == self.name
+            for target_name, alias_type, source, is_reverse in edges_from(current_name, current_author):
+                if target_name in visited_names:
+                    continue
+                visited_names.add(target_name)
+                results.append(TransitiveAlias(
+                    name=target_name,
+                    alias_type=alias_type,
+                    source=source,
+                    is_reverse=is_reverse,
+                    is_direct=is_direct,
+                ))
+                if alias_type not in NON_BRIDGING_ALIAS_TYPES:
+                    queue.append((target_name, Author.get_by_name(target_name)))
+
+        return results
+
 
 # 曲の作者のwebページの情報
 class AuthorLink(models.Model):
@@ -56,6 +111,7 @@ class AuthorAlias(models.Model):
         ("past", "以前の名称"),
         ("sns", "SNSでの名称"),
         ("spell", "表記揺れ"),
+        # 同一人物が運用している、本人公認の別名義（#1004）
         ("another", "別名義"),
         ("group", "グループ"),
     )
@@ -81,4 +137,29 @@ class EffectiveAlias:
 
     @property
     def alias_type_display(self):
+        return dict(AuthorAlias.CHOICES).get(self.alias_type, self.alias_type)
+
+
+@dataclass
+class TransitiveAlias:
+    """Author.get_transitive_aliases()が返す、推移的関係解決済みの別名1件分の情報
+
+    is_direct=Trueかつis_reverse=Falseの場合のみ、sourceは呼び出し元のauthorが
+    直接所有するAuthorAliasであり編集・削除の対象にできる。それ以外（is_direct=False、
+    またはis_reverse=True）の場合、sourceは他のauthorが所有するAuthorAliasであり
+    編集・削除の対象にはできない。
+
+    is_reverseはこのエントリを発見した最後の1ホップの向き（正方向か逆方向か）を表し、
+    alias_type="group"の場合の表示ラベルの出し分け（所属グループ/所属している名義）にも使う。
+    """
+    name: str
+    alias_type: str
+    source: AuthorAlias
+    is_reverse: bool = False
+    is_direct: bool = False
+
+    @property
+    def alias_type_display(self):
+        if self.alias_type == "group":
+            return "所属している名義" if self.is_reverse else "所属グループ"
         return dict(AuthorAlias.CHOICES).get(self.alias_type, self.alias_type)

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -682,6 +682,21 @@ DBアクセス（重複チェック）を伴うため `TestCase` を使用する
 | CHOICESに存在する値 | `alias_type="past"` | `"以前の名称"` を返す |
 | CHOICESに存在しない値 | `alias_type="unknown_type"` | 生の値をそのまま返す（フォールバック） |
 
+#### 11-3-3. `Author.get_transitive_aliases()`（推移的関係解決ロジック、#1005）
+
+具体例: 名義Aに「別名義B」「以前の名称C」「以前の名称D」「グループE」を登録した場合の5パターン全てを検証する。
+
+| テストケース | 操作 | 期待結果 |
+| --- | --- | --- |
+| 別名なし | 別名未登録のauthor | 空リストを返す |
+| Aの一覧 | `A.get_transitive_aliases()` | B(別名義,direct), C(以前の名称,direct), D(以前の名称,direct), E(所属グループ,direct) の4件 |
+| Bの一覧 | `B.get_transitive_aliases()` | A(別名義,direct,reverse)の1件のみ。`another`は中継点にならないためC/D/Eには辿らない |
+| Cの一覧 | `C.get_transitive_aliases()` | A(以前の名称,direct,reverse), B(別名義,indirect), D(以前の名称,indirect), E(所属グループ,indirect) の4件。`past`は中継点になるためAを経由してB/D/Eを発見する |
+| Dの一覧 | `D.get_transitive_aliases()` | A(以前の名称,direct,reverse), B(別名義,indirect), C(以前の名称,indirect), E(所属グループ,indirect) の4件 |
+| Eの一覧 | `E.get_transitive_aliases()` | A(所属している名義,direct,reverse)の1件のみ。`group`は中継点にならないためB/C/Dには辿らない |
+| 循環関係の終端 | `x`↔`y`が互いに`spell`の別名を保持（閉路） | 訪問済みノードとして扱われ無限ループにならず、重複なく1件のみ返す |
+| `TransitiveAlias.alias_type_display`（CHOICESに存在しない値） | `alias_type="unknown_type"` | 生の値をそのまま返す（フォールバック） |
+
 #### 11-4. `SongLink` モデル
 
 | テストケース | 操作 | 期待結果 |

--- a/subekashi/tests/test_models.py
+++ b/subekashi/tests/test_models.py
@@ -7,7 +7,7 @@ from django.db import IntegrityError
 from django.test import TestCase
 from django.utils import timezone
 from subekashi.models import Author, AuthorAlias, Contact, Editor, History, Song, SongLink
-from subekashi.models.author import EffectiveAlias
+from subekashi.models.author import EffectiveAlias, TransitiveAlias
 
 
 class AuthorModelTest(TestCase):
@@ -155,6 +155,89 @@ class AuthorEffectiveAliasesTest(TestCase):
         effective_alias = EffectiveAlias(name="foo_unknown", alias_type="unknown_type", source=alias)
 
         self.assertEqual(effective_alias.alias_type_display, "unknown_type")
+
+
+class AuthorTransitiveAliasesTest(TestCase):
+    """Author.get_transitive_aliases() の推移的関係解決ロジックのテスト（#1005）
+
+    #1003で確認された具体例（名義Aに別名義B・以前の名称C・以前の名称D・グループEを登録）を
+    そのまま再現し、各起点からの見え方が仕様表の通りになることを確認する。
+    """
+
+    def setUp(self):
+        self.a = Author.objects.create(name="author_a")
+        self.b = Author.objects.create(name="author_b")
+        self.c = Author.objects.create(name="author_c")
+        self.d = Author.objects.create(name="author_d")
+        self.e = Author.objects.create(name="author_e")
+        AuthorAlias.objects.create(name="author_b", author=self.a, alias_type="another")
+        AuthorAlias.objects.create(name="author_c", author=self.a, alias_type="past")
+        AuthorAlias.objects.create(name="author_d", author=self.a, alias_type="past")
+        AuthorAlias.objects.create(name="author_e", author=self.a, alias_type="group")
+
+    def as_tuples(self, transitive_aliases):
+        return {(t.name, t.alias_type_display, t.is_direct, t.is_reverse) for t in transitive_aliases}
+
+    def test_no_aliases_returns_empty_list(self):
+        lone = Author.objects.create(name="lone")
+        self.assertEqual(lone.get_transitive_aliases(), [])
+
+    def test_author_a_sees_all_four_directly(self):
+        result = self.as_tuples(self.a.get_transitive_aliases())
+        self.assertEqual(result, {
+            ("author_b", "別名義", True, False),
+            ("author_c", "以前の名称", True, False),
+            ("author_d", "以前の名称", True, False),
+            ("author_e", "所属グループ", True, False),
+        })
+
+    def test_author_b_sees_only_a_another_does_not_bridge(self):
+        result = self.as_tuples(self.b.get_transitive_aliases())
+        self.assertEqual(result, {
+            ("author_a", "別名義", True, True),
+        })
+
+    def test_author_c_sees_a_and_transitively_b_d_e_via_past(self):
+        result = self.as_tuples(self.c.get_transitive_aliases())
+        self.assertEqual(result, {
+            ("author_a", "以前の名称", True, True),
+            ("author_b", "別名義", False, False),
+            ("author_d", "以前の名称", False, False),
+            ("author_e", "所属グループ", False, False),
+        })
+
+    def test_author_d_sees_a_and_transitively_b_c_e_via_past(self):
+        result = self.as_tuples(self.d.get_transitive_aliases())
+        self.assertEqual(result, {
+            ("author_a", "以前の名称", True, True),
+            ("author_b", "別名義", False, False),
+            ("author_c", "以前の名称", False, False),
+            ("author_e", "所属グループ", False, False),
+        })
+
+    def test_author_e_sees_only_a_group_does_not_bridge(self):
+        result = self.as_tuples(self.e.get_transitive_aliases())
+        self.assertEqual(result, {
+            ("author_a", "所属している名義", True, True),
+        })
+
+    def test_cycle_terminates_without_duplicates(self):
+        x = Author.objects.create(name="cycle_x")
+        y = Author.objects.create(name="cycle_y")
+        AuthorAlias.objects.create(name="cycle_y", author=x, alias_type="spell")
+        AuthorAlias.objects.create(name="cycle_x", author=y, alias_type="spell")
+
+        result = x.get_transitive_aliases()
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0].name, "cycle_y")
+        self.assertEqual(result[0].alias_type, "spell")
+
+    def test_alias_type_display_falls_back_to_raw_value_for_unknown_type(self):
+        alias = AuthorAlias.objects.create(name="foo_unknown", author=self.a, alias_type="past")
+        transitive_alias = TransitiveAlias(name="foo_unknown", alias_type="unknown_type", source=alias)
+
+        self.assertEqual(transitive_alias.alias_type_display, "unknown_type")
 
 
 class SongModelTest(TestCase):


### PR DESCRIPTION
## 概要
#1003 の子issue #1005 の実装です。依存issue #1004 は main にマージ済みです。

`Author.get_effective_aliases()`（#989）は1ホップのみの解決のため、名義Aに別名義B・以前の名称Cの関係がある場合、B-Cの関係が見えない問題がありました。同一クラスタに属する別名をBFSで探索する新メソッド `Author.get_transitive_aliases()` を追加し、#1003で確認済みの以下のルールを実装します。

## ルール
1. 直接の関係（1ホップ、正方向・逆方向とも）は`alias_type`を問わず常に表示する
2. `alias_type`が`another`（別名義）・`group`（グループ）の関係は、そこから先の推移（2ホップ目以降の中継点）には使わない
3. `id`/`abbr`/`common`/`past`/`sns`/`spell`は中継点として使える

## 変更内容
- `subekashi/models/author.py`
  - `Author.get_transitive_aliases()` を追加（BFSで推移的関係を解決。訪問済みノードを記録し循環を防止）
  - 新設のデータクラス `TransitiveAlias` を追加
    - `is_direct`（1ホップかどうか）・`is_reverse`（最後の1ホップの向き）を分離して保持し、「自分が直接編集・削除できる別名」と「間接的に到達した別名」を区別できるようにした
    - `alias_type_display` で `group` の場合のみ視点に応じたラベルを出し分け（メンバー側「所属グループ」/グループ側「所属している名義」）。DB上の`alias_type`はどちらも`"group"`のまま
  - `AuthorAlias.CHOICES`の`another`にコメントを追加し、本人公認が前提であることを明記（#1004のUI説明文と表現を揃えた）
- `subekashi/tests/test_models.py`: #1003の具体例（A/B/C/D/E）5パターン全てが仕様表通りになることのテスト、循環関係が重複なく終了することのテストを追加
- `subekashi/tests/TEST_PLAN_UNIT.md`: 11-3-3節を追加

## 検証
- 一時的にbridging判定（another/group除外ロジック）を無効化し、`test_author_b_sees_only_a_another_does_not_bridge` / `test_author_e_sees_only_a_group_does_not_bridge` が実際に失敗することを確認した上で復元（テストが意図したロジックを検証できていることの確認）
- `python manage.py test subekashi.tests article.tests` (520件 OK)

## 非スコープ（後続issueで対応）
- Song検索フィルターへの適用（#1006）
- 一覧画面UIでの表示（#1007）

依存: #1004（マージ済み）
関連: #1003, #1006, #1007