### PR TITLE
feat: Song検索フィルターへの推移的関係解決の適用（#1006）

### DIFF
--- a/subekashi/lib/query_filters.py
+++ b/subekashi/lib/query_filters.py
@@ -1,35 +1,73 @@
+from collections import deque
 from django.db.models import BooleanField, Case, Exists, OuterRef, Q, Value, When
 from subekashi.constants.constants import ALL_MEDIAS
 from subekashi.lib.url import clean_url
 from subekashi.models import Author, AuthorAlias, SongLink
 
+# 中継点（推移的な探索での2ホップ目以降）として使える種別。
 # alias_type="another"（別名義）は同一人物が運用していても意図的に区別して扱うべきものであり、
-# 検索時に自動的に同一視されると意図しない結果になるため双方向解決の対象外とする（#996）
-# alias_type="group"（グループ）も本来はメンバー→グループの片方向のみの解決が必要だが、
-# その非対称ロジックは#1006で実装するため、それまでの暫定措置として双方向解決の対象外とする（#1004）
-EXCLUDED_FROM_BIDIRECTIONAL_ALIAS_TYPES = ("another", "group")
-BIDIRECTIONAL_ALIAS_TYPES = [
-    value for value, _ in AuthorAlias.CHOICES if value not in EXCLUDED_FROM_BIDIRECTIONAL_ALIAS_TYPES
-]
+# 検索では正方向・逆方向とも一切考慮しない（#996、#1004で撤回した「除外撤回」を再度撤回）。
+# alias_type="group"（グループ）はメンバー→グループの片方向のみ考慮する（#1006、詳細は#1003参照）。
+BRIDGING_ALIAS_TYPES = [value for value, _ in AuthorAlias.CHOICES if value not in ("another", "group")]
 
-# authorの別名（双方向）にマッチするQを返す
-# 正方向: authorに登録された別名がvalueにマッチする
-# 逆方向: nameがauthor.nameと一致する別名を他のauthorが持ち、その別名がvalueにマッチする場合、
-#         name側のauthorも対象にする（#989の双方向解決に対応）
-def filter_by_author_alias(lookup, value):
-    # name一致とalias_type制限を同一dictにまとめることで、複数aliasを持つauthorに対しても
-    # 同一のAuthorAlias行に対して両条件が適用されるようにする
-    # （否定条件(~Q)をANDすると多対多の行スコープが崩れるため、alias_type__inの正方向条件を使う）
-    forward_condition = Q(**{
-        f"authors__aliases__name__{lookup}": value,
-        "authors__aliases__alias_type__in": BIDIRECTIONAL_ALIAS_TYPES,
-    })
-    reverse_names = (
-        AuthorAlias.objects.exclude(alias_type__in=EXCLUDED_FROM_BIDIRECTIONAL_ALIAS_TYPES)
-        .filter(**{f"author__name__{lookup}": value})
-        .values("name")
+
+def _bridging_cluster(seed_names):
+    """seed_namesを起点に、BRIDGING_ALIAS_TYPESの関係のみを辿って到達できる
+    Author名の集合を返す（#1005のAuthor.get_transitive_aliases()と同じ、
+    another・groupを中継点にしないルールを名前の集合に対して適用したもの）。
+    """
+    visited = set(seed_names)
+    queue = deque(seed_names)
+    while queue:
+        name = queue.popleft()
+        author = Author.get_by_name(name)
+        neighbor_names = set()
+        if author is not None:
+            neighbor_names |= set(
+                author.aliases.filter(alias_type__in=BRIDGING_ALIAS_TYPES).values_list("name", flat=True)
+            )
+        neighbor_names |= set(
+            AuthorAlias.objects.filter(name=name, alias_type__in=BRIDGING_ALIAS_TYPES)
+            .exclude(author=author)
+            .values_list("author__name", flat=True)
+        )
+        for neighbor_name in neighbor_names:
+            if neighbor_name not in visited:
+                visited.add(neighbor_name)
+                queue.append(neighbor_name)
+    return visited
+
+
+def _resolve_author_alias_names(lookup, value):
+    """検索語(value)に対応する実効的なAuthor名の集合を返す（#1006）
+
+    - alias_type="another"は正方向・逆方向とも一切考慮しない
+    - alias_type="group"はメンバー→グループの片方向のみ考慮する
+      （グループ自身の名義で検索してもメンバー個々の曲は含めない）
+    - それ以外の種別（id/abbr/common/past/sns/spell）は推移的に双方向解決する
+    """
+    forward_owner_names = set(
+        AuthorAlias.objects.filter(**{f"name__{lookup}": value}, alias_type__in=BRIDGING_ALIAS_TYPES)
+        .values_list("author__name", flat=True)
     )
-    return forward_condition | Q(authors__name__in=reverse_names)
+    reverse_anchor_names = set(
+        Author.objects.filter(**{f"name__{lookup}": value}).values_list("name", flat=True)
+    )
+    seed_names = forward_owner_names | reverse_anchor_names
+    if not seed_names:
+        return set()
+
+    cluster_names = _bridging_cluster(seed_names)
+    group_target_names = set(
+        AuthorAlias.objects.filter(author__name__in=cluster_names, alias_type="group")
+        .values_list("name", flat=True)
+    )
+    return cluster_names | group_target_names
+
+
+# authorの別名（推移的な双方向解決を含む）にマッチするQを返す（#1005/#1006）
+def filter_by_author_alias(lookup, value):
+    return Q(authors__name__in=_resolve_author_alias_names(lookup, value))
 
 # 作者名によるフィルター（別名・双方向を含む、部分一致）
 def filter_by_author(value):

--- a/subekashi/lib/query_filters.py
+++ b/subekashi/lib/query_filters.py
@@ -3,38 +3,28 @@ from django.db.models import BooleanField, Case, Exists, OuterRef, Q, Value, Whe
 from subekashi.constants.constants import ALL_MEDIAS
 from subekashi.lib.url import clean_url
 from subekashi.models import Author, AuthorAlias, SongLink
-
-# 中継点（推移的な探索での2ホップ目以降）として使える種別。
-# alias_type="another"（別名義）は同一人物が運用していても意図的に区別して扱うべきものであり、
-# 検索では正方向・逆方向とも一切考慮しない（#996、#1004で撤回した「除外撤回」を再度撤回）。
-# alias_type="group"（グループ）はメンバー→グループの片方向のみ考慮する（#1006、詳細は#1003参照）。
-BRIDGING_ALIAS_TYPES = [value for value, _ in AuthorAlias.CHOICES if value not in ("another", "group")]
+from subekashi.models.author import NON_BRIDGING_ALIAS_TYPES, get_alias_edges
 
 
 def _bridging_cluster(seed_names):
-    """seed_namesを起点に、BRIDGING_ALIAS_TYPESの関係のみを辿って到達できる
-    Author名の集合を返す（#1005のAuthor.get_transitive_aliases()と同じ、
-    another・groupを中継点にしないルールを名前の集合に対して適用したもの）。
+    """seed_namesを起点に、NON_BRIDGING_ALIAS_TYPES（another・group）以外の
+    関係のみを辿って到達できるAuthor名の集合を返す。
+
+    #1005のAuthor.get_transitive_aliases()と同じ非中継ルールを、特定のAuthorに
+    紐付かない名前の集合に対して適用したもので、辺の取得自体はget_alias_edges()
+    を共通利用することでget_transitive_aliases()とロジックの二重化を避けている。
     """
     visited = set(seed_names)
     queue = deque(seed_names)
     while queue:
         name = queue.popleft()
         author = Author.get_by_name(name)
-        neighbor_names = set()
-        if author is not None:
-            neighbor_names |= set(
-                author.aliases.filter(alias_type__in=BRIDGING_ALIAS_TYPES).values_list("name", flat=True)
-            )
-        neighbor_names |= set(
-            AuthorAlias.objects.filter(name=name, alias_type__in=BRIDGING_ALIAS_TYPES)
-            .exclude(author=author)
-            .values_list("author__name", flat=True)
-        )
-        for neighbor_name in neighbor_names:
-            if neighbor_name not in visited:
-                visited.add(neighbor_name)
-                queue.append(neighbor_name)
+        for target_name, alias_type, _source, _is_reverse in get_alias_edges(name, author):
+            if alias_type in NON_BRIDGING_ALIAS_TYPES:
+                continue
+            if target_name not in visited:
+                visited.add(target_name)
+                queue.append(target_name)
     return visited
 
 
@@ -47,7 +37,8 @@ def _resolve_author_alias_names(lookup, value):
     - それ以外の種別（id/abbr/common/past/sns/spell）は推移的に双方向解決する
     """
     forward_owner_names = set(
-        AuthorAlias.objects.filter(**{f"name__{lookup}": value}, alias_type__in=BRIDGING_ALIAS_TYPES)
+        AuthorAlias.objects.filter(**{f"name__{lookup}": value})
+        .exclude(alias_type__in=NON_BRIDGING_ALIAS_TYPES)
         .values_list("author__name", flat=True)
     )
     reverse_anchor_names = set(

--- a/subekashi/models/author.py
+++ b/subekashi/models/author.py
@@ -7,6 +7,34 @@ from .base import GetOrNoneMixin
 NON_BRIDGING_ALIAS_TYPES = ("another", "group")
 
 
+def get_alias_edges(name, author):
+    """nameのノードから伸びるAuthorAliasの辺を全て返す（alias_typeによる絞り込みはしない）
+
+    (target_name, alias_type, source, is_reverse) のタプルのリストを返す。
+    正方向: authorが直接所有するAuthorAlias（authorがNone、つまりnameに対応する
+    Authorが実在しない場合は正方向の辺は存在しない）
+    逆方向: nameをname属性として持つ、他のauthorが所有するAuthorAlias
+
+    AuthorAlias.authorはnull不可のフィールドのため、authorがNoneの場合の
+    `.exclude(author=author)`（`.exclude(author=None)`）は何も除外しない
+    no-opとして働き、意図通りに動作する。
+
+    Author.get_transitive_aliases()（#1005）とsubekashi.lib.query_filtersの
+    検索フィルター（#1006）で共通利用する低レベルヘルパー。
+    """
+    edges = []
+    if author is not None:
+        edges += [
+            (alias.name, alias.alias_type, alias, False)
+            for alias in author.aliases.all()
+        ]
+    edges += [
+        (alias.author.name, alias.alias_type, alias, True)
+        for alias in AuthorAlias.objects.filter(name=name).exclude(author=author).select_related("author")
+    ]
+    return edges
+
+
 # 曲の作者の情報
 class Author(GetOrNoneMixin, models.Model):
     name = models.CharField(unique=True, max_length = 500)
@@ -57,19 +85,6 @@ class Author(GetOrNoneMixin, models.Model):
         最大2クエリ、中継可能な場合はさらにAuthor検索が1クエリ発行される）ため、
         巨大なクラスタに対して呼び出すとコストが大きくなる点に注意すること。
         """
-        def edges_from(name, author):
-            edges = []
-            if author is not None:
-                edges += [
-                    (alias.name, alias.alias_type, alias, False)
-                    for alias in author.aliases.all()
-                ]
-            edges += [
-                (alias.author.name, alias.alias_type, alias, True)
-                for alias in AuthorAlias.objects.filter(name=name).exclude(author=author).select_related("author")
-            ]
-            return edges
-
         visited_names = {self.name}
         results = []
         queue = deque([(self.name, self)])
@@ -77,7 +92,7 @@ class Author(GetOrNoneMixin, models.Model):
         while queue:
             current_name, current_author = queue.popleft()
             is_direct = current_name == self.name
-            for target_name, alias_type, source, is_reverse in edges_from(current_name, current_author):
+            for target_name, alias_type, source, is_reverse in get_alias_edges(current_name, current_author):
                 if target_name in visited_names:
                     continue
                 visited_names.add(target_name)

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -197,19 +197,33 @@
 | 逆方向・`alias_type=another` | owner自身のnameで検索 | target側の曲は結果に含まれない |
 | 同一ownerに`another`以外の別名も存在 | `another`の別名と`past`の別名を両方持つowner | `past`側の別名名での検索は通常通りヒットする（`another`の存在に影響されない） |
 
-#### 3-1-4. `alias_type="group"`（グループ）の暫定除外（#1004）
+#### 3-1-4. `alias_type="group"`（グループ）の片方向解決（#1006）
 
-`group`は本来メンバー→グループの片方向のみ解決されるべきだが、非対称ロジックの実装は#1006に
-委譲されているため、それまでの暫定措置として`another`と同様に双方向解決の対象外とする。
+`group`はメンバー→グループの片方向のみ考慮する。メンバー名義で検索するとグループ自身の
+曲もヒットするが、グループ名義で検索してもメンバー個々の曲はヒットしない（合作アカウントを
+介して他人の名義の曲が混入するのを防ぐ）。#1004時点では暫定的に双方向とも除外していたが、
+#1005の推移的関係解決を踏まえてこの非対称ルールに置き換えた。
 
 | テストケース | 前提条件 | 期待結果 |
 | --- | --- | --- |
-| 正方向・`alias_type=group` | ownerの別名(`alias_type="group"`)のnameで検索 | ownerの曲は結果に含まれない（target自身の曲のみヒット） |
-| 逆方向・`alias_type=group` | owner自身のnameで検索 | target側の曲は結果に含まれない |
-| 完全一致（`_exact`）・`alias_type=group` | ownerの別名(`alias_type="group"`)のnameで完全一致検索 | ownerの曲は結果に含まれない |
-| `filter_by_keyword`・`alias_type=group` | 同上のnameでkeyword検索 | ownerの曲は結果に含まれない |
-| `filter_by_guesser`・`alias_type=group` | 同上のnameでguesser検索 | ownerの曲は結果に含まれない |
-| 同一ownerに`group`以外の別名も存在 | `group`の別名と`past`の別名を両方持つowner | `past`側の別名名での検索は通常通りヒットする（`group`の存在に影響されない） |
+| メンバー名義で検索 | memberの別名(`alias_type="group"`)にgroupのnameを登録 | memberの曲・group自身の曲の両方がヒットする |
+| グループ名義で検索（`filter_by_author`） | 同上 | group自身の曲のみヒットし、memberの曲はヒットしない |
+| グループ名義で検索（`_exact`） | 同上 | 同上 |
+| グループ名義で検索（`filter_by_keyword`） | 同上 | 同上 |
+| グループ名義で検索（`filter_by_guesser`） | 同上 | 同上 |
+
+#### 3-1-5. 推移的関係解決の検索への適用（#1006）
+
+#1003で確認された具体例（名義Aに別名義B・以前の名称C・以前の名称D・グループEを登録）が、
+`filter_by_author_exact`で以下の検索結果になることを確認する結合テスト。
+
+| テストケース | 検索語 | 期待結果 |
+| --- | --- | --- |
+| Aで検索 | `tamura`(A) | A, C, D, E の曲がヒットする（Bは含まれない） |
+| Bで検索 | `inoue`(B) | Bの曲のみヒットする（`another`は中継点にならない） |
+| Cで検索 | `kobayashi`(C) | A, C, D, E の曲がヒットする（`past`経由でAを介してD・Eに到達） |
+| Dで検索 | `yoshida`(D) | A, C, D, E の曲がヒットする（Cと対称） |
+| Eで検索 | `watanabe`(E) | Eの曲のみヒットする（`group`は中継点にならない） |
 
 #### 3-2. `filter_by_lack()`
 

--- a/subekashi/tests/test_lib_query_filters.py
+++ b/subekashi/tests/test_lib_query_filters.py
@@ -288,52 +288,104 @@ class FilterByAuthorAliasAnotherTypeExcludedTest(TestCase):
         self.assertIn(self.song1, qs)
 
 
-class FilterByAuthorAliasGroupTypeExcludedTest(TestCase):
-    """alias_type="group"（グループ）が検索フィルターの双方向解決対象から暫定的に除外されることのテスト（#1004）
+class FilterByAuthorAliasGroupTypeAsymmetricTest(TestCase):
+    """alias_type="group"（グループ）が検索フィルターで片方向のみ考慮されることのテスト（#1006）
 
-    本来グループはメンバー→グループの片方向のみ解決されるべきだが、非対称ロジックの実装は
-    #1006に委譲されているため、それまでの暫定措置として双方向解決の対象外としている。
+    メンバー名義で検索した場合はグループ自身の曲もヒットするが、
+    グループ名義で検索してもメンバー個々の曲はヒットしない
+    （合作アカウントを介して他人の名義の曲が混入するのを防ぐため）。
+    #1004時点では暫定的に双方向とも除外していたが、その制限を#1006で緩和した。
     """
 
     def setUp(self):
-        self.owner = Author.objects.create(name="group_yamada")
-        self.target = Author.objects.create(name="group_sasaki")
-        self.song1 = Song.objects.create(title="GroupSong1")
-        self.song1.authors.add(self.owner)
-        self.song2 = Song.objects.create(title="GroupSong2")
-        self.song2.authors.add(self.target)
-        AuthorAlias.objects.create(name="group_sasaki", author=self.owner, alias_type="group")
+        self.member = Author.objects.create(name="group_member")
+        self.group = Author.objects.create(name="group_account")
+        self.member_song = Song.objects.create(title="MemberSong")
+        self.member_song.authors.add(self.member)
+        self.group_song = Song.objects.create(title="GroupSong")
+        self.group_song.authors.add(self.group)
+        AuthorAlias.objects.create(name="group_account", author=self.member, alias_type="group")
 
-    def test_filter_by_author_forward_excludes_group(self):
-        qs = Song.objects.filter(filter_by_author("group_sasaki")).distinct()
-        self.assertNotIn(self.song1, qs)
-        self.assertIn(self.song2, qs)
+    def test_member_search_also_hits_group_song(self):
+        qs = Song.objects.filter(filter_by_author("group_member")).distinct()
+        self.assertIn(self.member_song, qs)
+        self.assertIn(self.group_song, qs)
 
-    def test_filter_by_author_reverse_excludes_group(self):
-        qs = Song.objects.filter(filter_by_author("group_yamada")).distinct()
-        self.assertIn(self.song1, qs)
-        self.assertNotIn(self.song2, qs)
+    def test_group_search_does_not_hit_member_song(self):
+        qs = Song.objects.filter(filter_by_author("group_account")).distinct()
+        self.assertNotIn(self.member_song, qs)
+        self.assertIn(self.group_song, qs)
 
-    def test_filter_by_author_exact_excludes_group(self):
-        qs = Song.objects.filter(filter_by_author_exact("group_sasaki")).distinct()
-        self.assertNotIn(self.song1, qs)
-        self.assertIn(self.song2, qs)
+    def test_group_search_exact_does_not_hit_member_song(self):
+        qs = Song.objects.filter(filter_by_author_exact("group_account")).distinct()
+        self.assertNotIn(self.member_song, qs)
+        self.assertIn(self.group_song, qs)
 
-    def test_filter_by_keyword_excludes_group(self):
-        qs = Song.objects.filter(filter_by_keyword("group_sasaki")).distinct()
-        self.assertNotIn(self.song1, qs)
-        self.assertIn(self.song2, qs)
+    def test_group_search_keyword_does_not_hit_member_song(self):
+        qs = Song.objects.filter(filter_by_keyword("group_account")).distinct()
+        self.assertNotIn(self.member_song, qs)
+        self.assertIn(self.group_song, qs)
 
-    def test_filter_by_guesser_excludes_group(self):
-        qs = Song.objects.filter(filter_by_guesser("group_sasaki")).distinct()
-        self.assertNotIn(self.song1, qs)
-        self.assertIn(self.song2, qs)
+    def test_group_search_guesser_does_not_hit_member_song(self):
+        qs = Song.objects.filter(filter_by_guesser("group_account")).distinct()
+        self.assertNotIn(self.member_song, qs)
+        self.assertIn(self.group_song, qs)
 
-    def test_non_group_type_still_matches(self):
-        # 同じownerにグループ以外(past)の別名も追加した場合、そちらは通常通りヒットする
-        AuthorAlias.objects.create(name="group_yamada_past", author=self.owner, alias_type="past")
-        qs = Song.objects.filter(filter_by_author("group_yamada_past")).distinct()
-        self.assertIn(self.song1, qs)
+
+class FilterByAuthorAliasTransitiveResolutionTest(TestCase):
+    """#1003で確認された具体例（A/B/C/D/E）が検索フィルターの仕様表通りになることの結合テスト（#1006）
+
+    名義A(tamura)に「別名義B(inoue)」「以前の名称C(kobayashi)」「以前の名称D(yoshida)」
+    「グループE(watanabe)」を登録した場合、以下の検索結果になることを確認する。
+
+    | 検索語 | ヒットする曲の作者 |
+    | --- | --- |
+    | A | A, C, D, E |
+    | B | B のみ |
+    | C | A, C, D, E |
+    | D | A, C, D, E |
+    | E | E のみ |
+    """
+
+    def setUp(self):
+        self.a = Author.objects.create(name="tamura")
+        self.b = Author.objects.create(name="inoue")
+        self.c = Author.objects.create(name="kobayashi")
+        self.d = Author.objects.create(name="yoshida")
+        self.e = Author.objects.create(name="watanabe")
+        AuthorAlias.objects.create(name="inoue", author=self.a, alias_type="another")
+        AuthorAlias.objects.create(name="kobayashi", author=self.a, alias_type="past")
+        AuthorAlias.objects.create(name="yoshida", author=self.a, alias_type="past")
+        AuthorAlias.objects.create(name="watanabe", author=self.a, alias_type="group")
+
+        self.song_a = Song.objects.create(title="SongA")
+        self.song_a.authors.add(self.a)
+        self.song_b = Song.objects.create(title="SongB")
+        self.song_b.authors.add(self.b)
+        self.song_c = Song.objects.create(title="SongC")
+        self.song_c.authors.add(self.c)
+        self.song_d = Song.objects.create(title="SongD")
+        self.song_d.authors.add(self.d)
+        self.song_e = Song.objects.create(title="SongE")
+        self.song_e.authors.add(self.e)
+
+    def search(self, value):
+        return set(Song.objects.filter(filter_by_author_exact(value)).distinct())
+
+    def test_search_a_hits_a_c_d_e_not_b(self):
+        self.assertEqual(self.search("tamura"), {self.song_a, self.song_c, self.song_d, self.song_e})
+
+    def test_search_b_hits_only_b(self):
+        self.assertEqual(self.search("inoue"), {self.song_b})
+
+    def test_search_c_hits_a_c_d_e_not_b(self):
+        self.assertEqual(self.search("kobayashi"), {self.song_a, self.song_c, self.song_d, self.song_e})
+
+    def test_search_d_hits_a_c_d_e_not_b(self):
+        self.assertEqual(self.search("yoshida"), {self.song_a, self.song_c, self.song_d, self.song_e})
+
+    def test_search_e_hits_only_e(self):
+        self.assertEqual(self.search("watanabe"), {self.song_e})
 
 
 class FilterByLackTest(TestCase):


### PR DESCRIPTION
## 概要
#1003 の子issue #1006 の実装です。依存issue #1005 は main にマージ済みです。

`filter_by_author_alias`（#990/#996/#1004）を、#1005の推移的関係解決の考え方に基づいて書き換え、以下の非対称ルールを実装します。

## ルール
具体例: 名義Aに「別名義B」「以前の名称C」「以前の名称D」「グループE」を登録した場合

| 検索語 | ヒットする曲の作者 |
| --- | --- |
| A | A, C, D, E |
| B | B のみ |
| C | A, C, D, E |
| D | A, C, D, E |
| E | E のみ |

1. `another`（別名義）は検索では正方向・逆方向とも一切考慮しない（#996の元の挙動を維持。#1004時点で検討していた「除外撤回」は撤回を取り消し）
2. `group`（グループ）は片方向のみ考慮する（メンバー名義で検索→グループ自身の曲もヒット／グループ名義で検索→メンバー個々の曲はヒットしない）
3. それ以外の種別（`id`/`abbr`/`common`/`past`/`sns`/`spell`）は推移的に双方向解決する

## 実装方針
- `subekashi/lib/query_filters.py`
  - `_bridging_cluster(seed_names)`: 中継可能な種別（`another`・`group`を除く）のみを辿るBFS。#1005の`Author.get_transitive_aliases()`と同じ非中継ルールを、特定のAuthorに紐付かない名前の集合に対して適用したもの
  - `_resolve_author_alias_names(lookup, value)`: 検索語にマッチするAuthorAlias/Authorをアンカーとして拾い、`_bridging_cluster`でクラスタを解決した後、クラスタ内の各Authorが持つ`group`種別の別名を片方向のみ追加して、最終的なAuthor名の集合を返す
  - `filter_by_author_alias(lookup, value)`は`Q(authors__name__in=names)`に集約されるシンプルな形になった（forward_condition / reverse_namesの個別実装が不要になった）
  - `filter_by_author` / `filter_by_author_exact` / `filter_by_keyword` / `filter_by_guesser`は全て`filter_by_author_alias`経由のため変更不要

## テスト
- #1003の具体例（A/B/C/D/E）5パターン全てが表の通りの検索結果になることの結合テスト（`FilterByAuthorAliasTransitiveResolutionTest`）
- `another`が正方向・逆方向とも一切考慮されないことのテスト（既存の`FilterByAuthorAliasAnotherTypeExcludedTest`、変更なしで成立することを確認）
- `group`が片方向のみ考慮されることのテスト（`FilterByAuthorAliasGroupTypeAsymmetricTest`。#1004時点の`FilterByAuthorAliasGroupTypeExcludedTest`を置き換え）
- 既存の#990の1ホップ双方向解決のテスト（`FilterByAuthorTest`等）が引き続き成立することを確認
- 一時的に`_bridging_cluster`のBFS展開を無効化し、多ホップ系のテストが実際に失敗することを確認した上で復元（テストの実効性を検証）
- 実際に`runserver`を起動し、`/api/html/song_cards?author=...`にメンバー名義・グループ名義でリクエストして期待通りの絞り込みになることを確認（検証用データは確認後クリーンアップ済み）
- `python manage.py test subekashi.tests article.tests` (524件 OK)
- `TEST_PLAN_UNIT.md` 更新（3-1-3〜3-1-5）

## 非スコープ（#1007で対応）
- 一覧画面UIでの表示

依存: #1005（マージ済み）
関連: #1003, #1007