### PR TITLE
feat: 別名一覧画面の「以前の名称」逆方向表示を「その後の名称」に変更（#1019）

### DIFF
--- a/subekashi/models/author.py
+++ b/subekashi/models/author.py
@@ -165,7 +165,8 @@ class TransitiveAlias:
     編集・削除の対象にはできない。
 
     is_reverseはこのエントリを発見した最後の1ホップの向き（正方向か逆方向か）を表し、
-    alias_type="group"の場合の表示ラベルの出し分け（所属グループ/所属している名義）にも使う。
+    alias_type="group"の場合の表示ラベルの出し分け（所属グループ/所属している名義）、
+    alias_type="past"の場合の表示ラベルの出し分け（以前の名称/その後の名称、#1019）にも使う。
     """
     name: str
     alias_type: str
@@ -177,4 +178,6 @@ class TransitiveAlias:
     def alias_type_display(self):
         if self.alias_type == "group":
             return "所属している名義" if self.is_reverse else "所属グループ"
+        if self.alias_type == "past" and self.is_reverse:
+            return "その後の名称"
         return dict(AuthorAlias.CHOICES).get(self.alias_type, self.alias_type)

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -477,8 +477,10 @@ DBアクセス（重複チェック）を伴うため `TestCase` を使用する
 | `alias_type`がpast/another以外 | 例: `abbr`。対象authorは実在 | `channel/<name>/`へのリンクが含まれない |
 | 再読み込みボタン (#996) | 正常アクセス | `reloadPage()`呼び出しと`fa-redo`アイコンが含まれる |
 | 追加ボタンのアイコン (#996) | 正常アクセス | `fa-plus`アイコンが含まれる |
+| `alias_type=past`・正方向のラベル (#1019) | 自分がpastの別名を登録 | 「以前の名称」と表示される |
+| `alias_type=past`・逆方向のラベル (#1019) | 他authorが自分をpastの別名として登録 | 「その後の名称」と表示される |
 
-##### 推移的関係解決の反映（#1007）
+##### 推移的関係解決の反映（#1007、#1019）
 
 #1003・#1005の具体例（名義Aに別名義B・以前の名称C・以前の名称D・グループEを登録）を再現し、各authorの一覧画面が仕様表の通りになることを確認する。
 
@@ -486,7 +488,7 @@ DBアクセス（重複チェック）を伴うため `TestCase` を使用する
 | --- | --- | --- |
 | Aの一覧 | `A.get_transitive_aliases()`を表示 | B(別名義)・C(以前の名称)・D(以前の名称)・E(所属グループ)の4件が表示され、いずれも編集・削除リンクを含む（直接保有） |
 | Bの一覧 | 同上 | Aのみ表示される（`another`は中継点にならないためC/D/Eは表示されない）。編集・削除リンクは含まれない（逆方向） |
-| Cの一覧 | 同上 | A・B・D・Eが表示される（`past`経由でAを介して推移的に到達）。いずれも編集・削除リンクは含まれない（自分が直接保有する別名ではない） |
+| Cの一覧 | 同上 | A（その後の名称）・B・D（以前の名称）・Eが表示される（`past`経由でAを介して推移的に到達）。いずれも編集・削除リンクは含まれない（自分が直接保有する別名ではない） |
 | Eの一覧 | 同上 | Aのみ表示され、ラベルは「所属している名義」（`group`は中継点にならないためB/C/Dは表示されない）。編集・削除リンクは含まれない |
 | グループラベルの出し分け | 同上 | Aの一覧ではEの関係が「所属グループ」、Eの一覧ではAの関係が「所属している名義」と表示される |
 
@@ -714,17 +716,21 @@ DBアクセス（重複チェック）を伴うため `TestCase` を使用する
 #### 11-3-3. `Author.get_transitive_aliases()`（推移的関係解決ロジック、#1005）
 
 具体例: 名義Aに「別名義B」「以前の名称C」「以前の名称D」「グループE」を登録した場合の5パターン全てを検証する。
+`past`の関係は、正方向（自分がpastの別名を登録している側）では「以前の名称」、逆方向
+（相手が自分をpastの別名として登録している側）では「その後の名称」と表示する（#1019）。
 
 | テストケース | 操作 | 期待結果 |
 | --- | --- | --- |
 | 別名なし | 別名未登録のauthor | 空リストを返す |
 | Aの一覧 | `A.get_transitive_aliases()` | B(別名義,direct), C(以前の名称,direct), D(以前の名称,direct), E(所属グループ,direct) の4件 |
 | Bの一覧 | `B.get_transitive_aliases()` | A(別名義,direct,reverse)の1件のみ。`another`は中継点にならないためC/D/Eには辿らない |
-| Cの一覧 | `C.get_transitive_aliases()` | A(以前の名称,direct,reverse), B(別名義,indirect), D(以前の名称,indirect), E(所属グループ,indirect) の4件。`past`は中継点になるためAを経由してB/D/Eを発見する |
-| Dの一覧 | `D.get_transitive_aliases()` | A(以前の名称,direct,reverse), B(別名義,indirect), C(以前の名称,indirect), E(所属グループ,indirect) の4件 |
+| Cの一覧 | `C.get_transitive_aliases()` | A(その後の名称,direct,reverse), B(別名義,indirect), D(以前の名称,indirect), E(所属グループ,indirect) の4件。`past`は中継点になるためAを経由してB/D/Eを発見する |
+| Dの一覧 | `D.get_transitive_aliases()` | A(その後の名称,direct,reverse), B(別名義,indirect), C(以前の名称,indirect), E(所属グループ,indirect) の4件 |
 | Eの一覧 | `E.get_transitive_aliases()` | A(所属している名義,direct,reverse)の1件のみ。`group`は中継点にならないためB/C/Dには辿らない |
 | 循環関係の終端 | `x`↔`y`が互いに`spell`の別名を保持（閉路） | 訪問済みノードとして扱われ無限ループにならず、重複なく1件のみ返す |
 | `TransitiveAlias.alias_type_display`（CHOICESに存在しない値） | `alias_type="unknown_type"` | 生の値をそのまま返す（フォールバック） |
+| `TransitiveAlias.alias_type_display`（`past`・正方向、#1019） | `alias_type="past"`, `is_reverse=False` | `"以前の名称"` を返す |
+| `TransitiveAlias.alias_type_display`（`past`・逆方向、#1019） | `alias_type="past"`, `is_reverse=True` | `"その後の名称"` を返す |
 
 #### 11-4. `SongLink` モデル
 

--- a/subekashi/tests/test_models.py
+++ b/subekashi/tests/test_models.py
@@ -200,7 +200,7 @@ class AuthorTransitiveAliasesTest(TestCase):
     def test_author_c_sees_a_and_transitively_b_d_e_via_past(self):
         result = self.as_tuples(self.c.get_transitive_aliases())
         self.assertEqual(result, {
-            ("author_a", "以前の名称", True, True),
+            ("author_a", "その後の名称", True, True),
             ("author_b", "別名義", False, False),
             ("author_d", "以前の名称", False, False),
             ("author_e", "所属グループ", False, False),
@@ -209,7 +209,7 @@ class AuthorTransitiveAliasesTest(TestCase):
     def test_author_d_sees_a_and_transitively_b_c_e_via_past(self):
         result = self.as_tuples(self.d.get_transitive_aliases())
         self.assertEqual(result, {
-            ("author_a", "以前の名称", True, True),
+            ("author_a", "その後の名称", True, True),
             ("author_b", "別名義", False, False),
             ("author_c", "以前の名称", False, False),
             ("author_e", "所属グループ", False, False),
@@ -238,6 +238,20 @@ class AuthorTransitiveAliasesTest(TestCase):
         transitive_alias = TransitiveAlias(name="foo_unknown", alias_type="unknown_type", source=alias)
 
         self.assertEqual(transitive_alias.alias_type_display, "unknown_type")
+
+    def test_alias_type_display_past_forward_stays_zenno_no_meisho(self):
+        # #1019: 正方向（自分がpastの別名を登録している側）は従来通り「以前の名称」のまま
+        alias = AuthorAlias.objects.create(name="foo_past_forward", author=self.a, alias_type="past")
+        transitive_alias = TransitiveAlias(name="foo_past_forward", alias_type="past", source=alias, is_reverse=False)
+
+        self.assertEqual(transitive_alias.alias_type_display, "以前の名称")
+
+    def test_alias_type_display_past_reverse_shows_sonogo_no_meisho(self):
+        # #1019: 逆方向（相手が自分をpastの別名として登録している側）は「その後の名称」と表示する
+        alias = AuthorAlias.objects.create(name="foo_past_reverse", author=self.a, alias_type="past")
+        transitive_alias = TransitiveAlias(name="foo_past_reverse", alias_type="past", source=alias, is_reverse=True)
+
+        self.assertEqual(transitive_alias.alias_type_display, "その後の名称")
 
 
 class SongModelTest(TestCase):

--- a/subekashi/tests/test_views.py
+++ b/subekashi/tests/test_views.py
@@ -474,6 +474,24 @@ class AuthorAliasesViewTest(TestCase):
         self.assertNotContains(response, reverse("subekashi:author_alias_edit", args=[self.author.id, alias.id]))
         self.assertNotContains(response, reverse("subekashi:author_alias_delete", args=[self.author.id, alias.id]))
 
+    def test_forward_past_alias_shows_izen_no_meisho(self):
+        # #1019: 正方向（自分がpastの別名を登録している側）は「以前の名称」のまま
+        AuthorAlias.objects.create(name="以前の名称対象", author=self.author, alias_type="past")
+
+        response = self.client.get(reverse("subekashi:author_aliases", args=[self.author.id]))
+
+        self.assertContains(response, "以前の名称")
+        self.assertNotContains(response, "その後の名称")
+
+    def test_reverse_past_alias_shows_sonogo_no_meisho(self):
+        # #1019: 逆方向（相手が自分をpastの別名として登録している側）は「その後の名称」と表示する
+        target = Author.objects.create(name="その後の名称対象")
+        AuthorAlias.objects.create(name=self.author.name, author=target, alias_type="past")
+
+        response = self.client.get(reverse("subekashi:author_aliases", args=[self.author.id]))
+
+        self.assertContains(response, "その後の名称")
+
     def test_past_alias_with_existing_author_links_to_channel(self):
         Author.objects.create(name="別名チャンネル対象")
         AuthorAlias.objects.create(name="別名チャンネル対象", author=self.author, alias_type="past")
@@ -562,6 +580,9 @@ class AuthorAliasesViewTransitiveResolutionTest(TestCase):
         self.assertContains(response, "view_yoshida")
         self.assertContains(response, "view_watanabe")
         self.assertContains(response, "所属グループ")
+        # Aへの関係は逆方向のため「その後の名称」、Dへの関係は間接的だが正方向のため「以前の名称」のまま（#1019）
+        self.assertContains(response, "その後の名称")
+        self.assertContains(response, "以前の名称")
         # Aへの関係は逆方向、B/D/Eへの関係は間接的なため、いずれも編集・削除できない
         self.assertNotContains(response, "fa-pen")
 


### PR DESCRIPTION
## 概要
#1003 の子issue #1019 の実装です。依存issue #1005 は main にマージ済みです。

別名一覧画面で`alias_type="past"`（以前の名称）の関係を表示する際、これまでは正方向・逆方向とも「以前の名称」という同一表記でした（#1003で「シンプルさを優先し一貫表記にする」方針を確認済み）が、逆方向（相手が自分をpastの別名として登録している側）だと実態と逆の意味に読めて分かりにくいとの指摘があり、「その後の名称」と表示するよう変更します。

## 変更内容
- `subekashi/models/author.py`: `TransitiveAlias.alias_type_display`に、`alias_type="past"`かつ`is_reverse=True`の場合の分岐を追加
  - `group`の所属グループ/所属している名義の出し分けと同じ方針。DB上の`alias_type`は正方向・逆方向とも`"past"`のままで、表示ラベルのみを切り替える
  - 推移的に間接到達した場合も、最後の1ホップの向き（`is_reverse`）に応じて同様に出し分けられる
  - `AuthorAliasesView`はこのプロパティをそのまま使っているため、ビュー・テンプレート側の変更は不要

## テスト
- `TransitiveAlias.alias_type_display`の単体テスト（正方向は「以前の名称」のまま、逆方向は「その後の名称」）
- `AuthorAliasesView`のビューテスト（正方向・逆方向それぞれのラベル表示、推移的に到達した場合のラベル）
- 一時的にラベル切り替えロジックを削除し、新規・既存テストが実際に失敗することを確認した上で復元（テストの実効性を検証）
- 実際に`runserver`を起動し、正方向・逆方向それぞれのAuthorページでラベルが正しく表示されることを確認（検証用データは確認後削除済み）
- `python manage.py test subekashi.tests article.tests` (534件 OK)
- `TEST_PLAN_UNIT.md` 更新（7-8-1、11-3-3）

## 非スコープ
- new/edit画面の`alias_type`選択肢自体（`AuthorAlias.CHOICES`、`ALIAS_TYPE_DESCRIPTIONS`）は変更なし
- Song検索フィルターへの影響なし（表示ラベルのみの変更）

依存: #1005（マージ済み）
関連: #1003