### PR TITLE
perf: TransitiveAliasに解決済みauthor_idを持たせ、遷移アイコン算出時の二重クエリを削減（#1023）

### DIFF
--- a/subekashi/models/author.py
+++ b/subekashi/models/author.py
@@ -82,8 +82,16 @@ class Author(GetOrNoneMixin, models.Model):
         無限ループ・重複を防ぐ。
 
         訪問するノード数に比例してクエリが発行される（各ノードごとに正方向・逆方向で
-        最大2クエリ、中継可能な場合はさらにAuthor検索が1クエリ発行される）ため、
-        巨大なクラスタに対して呼び出すとコストが大きくなる点に注意すること。
+        最大2クエリ、正方向かつ中継可能な場合はさらにAuthor検索が1クエリ発行される）
+        ため、巨大なクラスタに対して呼び出すとコストが大きくなる点に注意すること。
+
+        各エントリのTransitiveAlias.author_idには、可能な範囲で追加クエリなしに
+        解決できたauthor idを設定する（逆方向は所有者自身が実体のためselect_related
+        済みのデータから、正方向かつ中継可能な種別は中継探索のためどのみち発行される
+        Author検索から、それぞれ追加コストなしに取得する）。正方向かつ中継不可な種別
+        （another/group）は中継探索を行わないため解決されず、Noneのままになる。
+        呼び出し側でこの名前に対応するAuthorの有無が必要な場合は、author_idがNoneの
+        エントリに限定して補完的に問い合わせること（#1023）。
         """
         visited_names = {self.name}
         results = []
@@ -96,15 +104,27 @@ class Author(GetOrNoneMixin, models.Model):
                 if target_name in visited_names:
                     continue
                 visited_names.add(target_name)
+
+                if is_reverse:
+                    # 逆方向はこの行の所有者(source.author)がtarget_nameの実体そのもの。
+                    # get_alias_edges()内でselect_related済みのため追加クエリは発生しない
+                    target_author = source.author
+                elif alias_type not in NON_BRIDGING_ALIAS_TYPES:
+                    # 正方向かつ中継可能な種別のみ、中継探索のためにAuthorを解決する
+                    target_author = Author.get_by_name(target_name)
+                else:
+                    target_author = None
+
                 results.append(TransitiveAlias(
                     name=target_name,
                     alias_type=alias_type,
                     source=source,
                     is_reverse=is_reverse,
                     is_direct=is_direct,
+                    author_id=target_author.id if target_author is not None else None,
                 ))
                 if alias_type not in NON_BRIDGING_ALIAS_TYPES:
-                    queue.append((target_name, Author.get_by_name(target_name)))
+                    queue.append((target_name, target_author))
 
         return results
 
@@ -167,12 +187,17 @@ class TransitiveAlias:
     is_reverseはこのエントリを発見した最後の1ホップの向き（正方向か逆方向か）を表し、
     alias_type="group"の場合の表示ラベルの出し分け（所属グループ/所属している名義）、
     alias_type="past"の場合の表示ラベルの出し分け（以前の名称/その後の名称、#1019）にも使う。
+
+    author_idはnameに対応する実在Authorのid（存在しない場合はNone）。
+    get_transitive_aliases()が追加クエリなしに解決できた範囲でのみ設定され、
+    正方向かつalias_typeが"another"・"group"のエントリは常にNoneになる（#1023）。
     """
     name: str
     alias_type: str
     source: AuthorAlias
     is_reverse: bool = False
     is_direct: bool = False
+    author_id: int = None
 
     @property
     def alias_type_display(self):

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -502,6 +502,15 @@ DBアクセス（重複チェック）を伴うため `TestCase` を使用する
 | グループラベルの出し分け | 同上 | Aの一覧ではEの関係が「所属グループ」、Eの一覧ではAの関係が「所属している名義」と表示される |
 | 対応するAuthorが不在の別名のフォールバック | pがghost(past、Author不在)とr(past、Author実在)の別名を持ち、rの一覧を表示 | pへの関係は直接だが逆方向で編集できず、pは実在するため遷移アイコンが表示される。一方ghostへの関係は間接的で対応する実在Authorがないため、フォールバックとして所有者p自身の一覧画面への遷移アイコンが表示される（結果としてpの一覧へのリンクが2件表示される） |
 
+##### 遷移先author idの補完クエリの範囲（#1023）
+
+`AuthorAliasesView`は`TransitiveAlias.author_id`（#1023で追加。`get_transitive_aliases()`が追加クエリなしに解決した範囲でのみ設定される）を優先して使い、`author_id`が`None`の行（正方向かつ`another`/`group`のリーフエッジ）に限定して補完的にAuthorを問い合わせる。この対象はクラスタ全体ではなく未解決の名前のみのため、クラスタが大きくなっても補完クエリのIN句が際限なく大きくなることはない。
+
+| テストケース | 条件 | 期待結果 |
+| --- | --- | --- |
+| クエリ数の回帰防止 | Cの一覧を表示（A・Dはauthor_id解決済み、B・Eは未解決） | ビューの総クエリ数が想定通り（9件）に収まる |
+| 補完クエリの対象範囲 | 同上 | 補完クエリのIN句にB・Eの名前のみが含まれ、解決済みのA・Dの名前は含まれない |
+
 #### 7-8-2. `AuthorAliasNewView` (`/authors/<id>/aliases/new`)（#992）
 
 | テストケース | 条件 | 期待結果 |
@@ -741,6 +750,8 @@ DBアクセス（重複チェック）を伴うため `TestCase` を使用する
 | `TransitiveAlias.alias_type_display`（CHOICESに存在しない値） | `alias_type="unknown_type"` | 生の値をそのまま返す（フォールバック） |
 | `TransitiveAlias.alias_type_display`（`past`・正方向、#1019） | `alias_type="past"`, `is_reverse=False` | `"以前の名称"` を返す |
 | `TransitiveAlias.alias_type_display`（`past`・逆方向、#1019） | `alias_type="past"`, `is_reverse=True` | `"その後の名称"` を返す |
+| `TransitiveAlias.author_id`（逆方向・正方向かつ中継可能、#1023） | AのA.get_transitive_aliases()でC/D（past、正方向）、CのC.get_transitive_aliases()でA（past、逆方向）等 | 追加クエリなしに解決済みのauthor idが設定される |
+| `TransitiveAlias.author_id`（正方向かつ中継不可、#1023） | AのA.get_transitive_aliases()でB（another）・E（group）、CのC.get_transitive_aliases()でB・E（間接的） | `None`のまま（get_transitive_aliases()内では解決されない） |
 
 #### 11-4. `SongLink` モデル
 

--- a/subekashi/tests/test_models.py
+++ b/subekashi/tests/test_models.py
@@ -221,6 +221,34 @@ class AuthorTransitiveAliasesTest(TestCase):
             ("author_a", "所属している名義", True, True),
         })
 
+    def test_author_id_resolves_for_reverse_and_bridging_forward_entries(self):
+        # #1023: 逆方向、および正方向かつ中継可能な種別（past等）のエントリは、
+        # get_transitive_aliases()自体が追加クエリなしに解決したauthor_idを持つ
+        by_name = {t.name: t.author_id for t in self.a.get_transitive_aliases()}
+        self.assertEqual(by_name["author_c"], self.c.id)
+        self.assertEqual(by_name["author_d"], self.d.id)
+
+        by_name = {t.name: t.author_id for t in self.c.get_transitive_aliases()}
+        self.assertEqual(by_name["author_a"], self.a.id)
+        self.assertEqual(by_name["author_d"], self.d.id)
+
+        by_name = {t.name: t.author_id for t in self.b.get_transitive_aliases()}
+        self.assertEqual(by_name["author_a"], self.a.id)
+
+        by_name = {t.name: t.author_id for t in self.e.get_transitive_aliases()}
+        self.assertEqual(by_name["author_a"], self.a.id)
+
+    def test_author_id_is_none_for_non_bridging_forward_entries(self):
+        # #1023: 正方向かつalias_typeがanother/group（中継不可）のエントリは、
+        # get_transitive_aliases()内では解決されずauthor_idがNoneのままになる
+        by_name = {t.name: t.author_id for t in self.a.get_transitive_aliases()}
+        self.assertIsNone(by_name["author_b"])
+        self.assertIsNone(by_name["author_e"])
+
+        by_name = {t.name: t.author_id for t in self.c.get_transitive_aliases()}
+        self.assertIsNone(by_name["author_b"])
+        self.assertIsNone(by_name["author_e"])
+
     def test_cycle_terminates_without_duplicates(self):
         x = Author.objects.create(name="cycle_x")
         y = Author.objects.create(name="cycle_y")

--- a/subekashi/tests/test_views.py
+++ b/subekashi/tests/test_views.py
@@ -5,7 +5,9 @@
 ManifestStaticFilesStorage はテストに不要なため StaticFilesStorage に差し替える。
 """
 from unittest.mock import patch
+from django.db import connection
 from django.test import TestCase, Client, override_settings
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 from subekashi.forms import AuthorAliasForm
 from subekashi.models import Ad, Author, AuthorAlias, Contact, Editor, History, Song
@@ -635,6 +637,32 @@ class AuthorAliasesViewTransitiveResolutionTest(TestCase):
         self.assertContains(response, reverse("subekashi:author_aliases", args=[self.b.id]))
         self.assertContains(response, reverse("subekashi:author_aliases", args=[self.d.id]))
         self.assertContains(response, reverse("subekashi:author_aliases", args=[self.e.id]))
+
+    def test_author_c_list_query_count_is_bounded(self):
+        # #1023: 遷移先author idの補完的な問い合わせが、クラスタ全体ではなく
+        # 未解決の名前(B・E)のみを対象にした1クエリに収まっていることの回帰防止テスト。
+        # クエリ数が増えた場合はこの値を更新しつつ、原因を確認すること
+        with self.assertNumQueries(9):
+            self.client.get(reverse("subekashi:author_aliases", args=[self.c.id]))
+
+    def test_author_c_list_unresolved_query_scope_excludes_resolved_names(self):
+        # #1023: 補完的な問い合わせのIN句が、get_transitive_aliases()側で既に
+        # author_idを解決済みのA・D（別名一覧に4件とも表示されるが、A・Dはauthor_idが
+        # 解決済みのため対象外になるはず）を含まず、未解決のB・Eのみに絞られていることを
+        # 直接確認する（クエリ数だけではクラスタ全体を対象にする regression を検知できないため）
+        with CaptureQueriesContext(connection) as ctx:
+            self.client.get(reverse("subekashi:author_aliases", args=[self.c.id]))
+
+        unresolved_queries = [
+            q for q in ctx.captured_queries
+            if 'subekashi_author"."name" IN' in q["sql"]
+        ]
+        self.assertEqual(len(unresolved_queries), 1)
+        sql = unresolved_queries[0]["sql"]
+        self.assertIn("view_inoue", sql)
+        self.assertIn("view_watanabe", sql)
+        self.assertNotIn("view_tamura", sql)
+        self.assertNotIn("view_yoshida", sql)
 
     def test_author_e_list_shows_only_a_group_does_not_bridge(self):
         response = self.client.get(reverse("subekashi:author_aliases", args=[self.e.id]))

--- a/subekashi/views/author_alias.py
+++ b/subekashi/views/author_alias.py
@@ -47,20 +47,19 @@ class AuthorAliasesView(View):
 
         transitive_aliases = author.get_transitive_aliases()
 
-        # 各別名nameに対応する実在Authorのidを一括取得する。
-        # channelリンクの判定と、編集可能な行での遷移先（別名自体の一覧画面）の算出に使う。
-        # IN句の対象はクラスタ内の全別名名のため、get_transitive_aliases()自体が
-        # 既にクラスタサイズに比例したコストを持つ点と合わせて、巨大なクラスタでは
-        # このクエリのコストも大きくなる点に注意すること
-        author_ids_by_name = dict(
-            Author.objects.filter(
-                name__in=[ta.name for ta in transitive_aliases]
-            ).values_list("name", "id")
-        )
+        # get_transitive_aliases()が追加クエリなしに解決できなかった行（正方向かつ
+        # another/groupのリーフエッジのみ）に限定して、対応する実在Authorのidを
+        # 補完的に一括取得する。対象はクラスタ全体ではなく未解決の一部の名前に限られる
+        # ため、クラスタが大きくなってもこのクエリのIN句が際限なく大きくなることはない（#1023）
+        unresolved_names = [ta.name for ta in transitive_aliases if ta.author_id is None]
+        resolved_ids_by_name = dict(
+            Author.objects.filter(name__in=unresolved_names).values_list("name", "id")
+        ) if unresolved_names else {}
 
         alias_rows = []
         for ta in transitive_aliases:
             is_editable = ta.is_direct and not ta.is_reverse
+            matched_author_id = ta.author_id if ta.author_id is not None else resolved_ids_by_name.get(ta.name)
 
             # 別名自体(ta.name)に対応する実在Authorを優先して遷移先にする。
             # 対応するAuthorがない場合、このAuthorAlias自体を実際に所有している
@@ -68,7 +67,7 @@ class AuthorAliasesView(View):
             # 確実にリンクできる）。編集可能な行（is_editable=True）はsource.authorが
             # 常に自分自身であるため、下のif next_alias_author_id == author.idで
             # 結果的にNoneに戻る（フォールバックしても意味がないという意図の通り）
-            next_alias_author_id = author_ids_by_name.get(ta.name)
+            next_alias_author_id = matched_author_id
             if next_alias_author_id is None:
                 next_alias_author_id = ta.source.author_id
 
@@ -81,7 +80,7 @@ class AuthorAliasesView(View):
                 "alias_type_display": ta.alias_type_display,
                 "is_editable": is_editable,
                 "alias_id": ta.source.id,
-                "show_channel_link": ta.alias_type in LINKABLE_ALIAS_TYPES and ta.name in author_ids_by_name,
+                "show_channel_link": ta.alias_type in LINKABLE_ALIAS_TYPES and matched_author_id is not None,
                 "next_alias_author_id": next_alias_author_id,
             })
 


### PR DESCRIPTION
## 概要
#1021 のコードレビューで指摘された、将来的な最適化案の実装です。

`Author.get_transitive_aliases()`（#1005）のBFS内部では、中継探索のために各ノードで`Author.get_by_name()`を呼んでおり、その結果は中継判定にのみ使われ破棄されていました。一方`AuthorAliasesView`（#1021）では、遷移アイコンの遷移先算出のために、全別名nameに対して改めてAuthorを一括問い合わせしていました。これは一部重複した情報の再取得になっていたため、`TransitiveAlias`に解決済みのauthor idを持たせ、ビュー側の問い合わせを縮小しました。

## 解決ロジック
`TransitiveAlias.author_id`は、追加クエリなしに解決できる範囲でのみ設定されます。

- **逆方向のエントリ**: このAuthorAlias行の所有者(`source.author`)が対象の実体そのもの。`get_alias_edges()`内でselect_related済みのため新規クエリはゼロ（むしろ従来はここでも`Author.get_by_name()`を再度呼んでいたため、1クエリ削減）
- **正方向かつ中継可能な種別**（past等）: 中継探索のためどのみち発行される`Author.get_by_name()`の結果を流用（クエリ数変化なし）
- **正方向かつ中継不可な種別**（another/group）: 中継探索を行わないため解決しない。`author_id`は`None`のまま

`AuthorAliasesView`は、`author_id`が`None`の行（正方向かつanother/groupのリーフエッジのみ）に限定して補完的にAuthorを一括問い合わせします。対象はクラスタ全体ではなく未解決の一部の名前のみになるため、クラスタが大きくなっても補完クエリのIN句が際限なく大きくなることはありません。

## 変更内容
- `subekashi/models/author.py`: `TransitiveAlias`に`author_id`フィールドを追加。`get_transitive_aliases()`が上記ロジックで解決
- `subekashi/views/author_alias.py`: `author_ids_by_name`の全件問い合わせを、`author_id is None`の行に限定した`unresolved_names`への問い合わせに変更

## テスト
- `author_id`が想定通り解決される（逆方向・正方向かつ中継可能）/解決されない（正方向かつanother/group）ことのモデルレベルテスト
- ビューの総クエリ数（9件）の回帰防止テスト
- 補完クエリのIN句が未解決の名前のみに絞られ、解決済みの名前を含まないことを直接検証するテスト
- 一時的に解決ロジック・絞り込み条件をそれぞれ無効化し、新規テストが実際に失敗することを確認した上で復元（テストの実効性を検証）
- 実際に`runserver`を起動し、実データ（`/authors/134/aliases/`・`/authors/2533/aliases/`）で遷移アイコンの表示・遷移先が変更前と一致することを確認
- `python manage.py test subekashi.tests article.tests` (542件 OK)
- `TEST_PLAN_UNIT.md` 更新（7-8-1、11-3-3）

依存: #1021（マージ済み）
関連: #1003