### PR TITLE
docs: TEST_PLAN_INTEGRATION.mdの一番有名な名義シナリオを#1029の仕様変更に合わせて更新

### DIFF
--- a/subekashi/tests/TEST_PLAN_INTEGRATION.md
+++ b/subekashi/tests/TEST_PLAN_INTEGRATION.md
@@ -487,20 +487,22 @@ YouTube Data API は外部サービスのため、`unittest.mock.patch` でモ�
 | 操作 | `AuthorAliasForm.clean_name` の重複チェックをモックでバイパスした状態で、同じ `name="foo_sub"` を新規登録POST |
 | 検証 | DB制約(`IntegrityError`)を`AuthorAliasNewView`が捕捉し、500エラーにならずHTTP 200のままフォームエラーが表示される。`AuthorAlias`は重複作成されない |
 
-#### 11-9. 一番有名な名義の選択から曲登録正規化まで（#1008）
+#### 11-9. 一番有名な名義の選択から曲登録正規化まで（#1008、#1029）
 
-**テストファイル**: `tests/test_views.py`（`AuthorPrimaryNameSetViewTest`）、`tests/test_lib_author_helpers.py`
+**テストファイル**: `tests/test_views.py`（`AuthorPrimaryNameSetViewTest`、`AuthorPrimaryNameConfirmViewTest`）、`tests/test_lib_author_helpers.py`
 
 | 項目 | 内容 |
 | --- | --- |
 | 前提 | `Author(name="foo")` に別名 `foo_old`(`alias_type="past"`) が登録済み。`foo_old`という名前の別Authorは存在しない |
-| 操作 | `POST /authors/<foo.id>/aliases/primary` に `name="foo_old"` |
+| 操作 | `GET /authors/<foo.id>/aliases/primary/confirm/` に `name="foo_old"` |
+| 検証 | 変更内容の確認画面（対象Songの一覧＋「の名義を『foo_old』に変更されます」）が表示される |
+| 操作 | 確認画面から `POST /authors/<foo.id>/aliases/primary` に `name="foo_old"` |
 | 検証 | `Author.name`が`"foo_old"`に入れ替わり、旧名`"foo"`が新たな`past`別名として再登録される。`?toast=primary`付きで一覧画面へリダイレクト |
 | 検証 | `History`に`history_type="edit"`のレコードが作成され、`send_discord()`が変更前後の名前を含む内容で呼ばれる |
 | 操作（正規化の確認） | 上記の状態変更後、`POST /songs/new/` の`authors`に旧名`"foo"`を指定して曲登録 |
-| 検証 | `get_or_create_authors()`が`"foo"`を`past`別名として解決し、新規Authorを作らず`Author(name="foo_old")`（同一のAuthor行）に紐づく |
-| 操作（衝突ケース） | 選択したpast別名の名前と完全一致する別のAuthorが既に存在する状態で `POST /authors/<foo.id>/aliases/primary` |
-| 検証 | `Author.name`は変更されず、`?toast=primary_error`付きでリダイレクトされる（マージは行われない） |
+| 検証 | `get_or_create_authors()`が`"foo"`を`past`別名として解決し、新規Authorを作らず`Author(name="foo_old")`（同一のAuthor行）に紐づく。redirect先URLに`primary_name_normalized=1`が付与され、遷移先画面でinfoトーストが表示される |
+| 操作（衝突ケース、#1029で仕様変更） | 選択したpast別名の名前と完全一致する別Author（conflicting_author）が既に存在する状態で `POST /authors/<foo.id>/aliases/primary` に `name="foo_old"` |
+| 検証 | かつては選択自体をブロックしていたが、#1029でconflicting_authorのSong・AuthorLink・AuthorAliasを全て`foo`に付け替えた上でconflicting_authorを削除する自動統合（マージ）に変更された。`Author.name`が`"foo_old"`に変わり、`?toast=primary`付きで一覧画面へリダイレクトされる |
 
 ---
 


### PR DESCRIPTION
## Summary
- #1030（#1029）でPRマージ後、#1008関連の残issueを確認する中で見つかったドキュメントの食い違いを修正
- `TEST_PLAN_INTEGRATION.md` 11-9節が、#1029で仕様変更する前の挙動（衝突時は選択をブロックしマージは行わない）のまま記載されており、実際の実装（確認画面を経由し、衝突するAuthorを自動統合するフロー）と食い違っていた
- テストコード自体の変更はなく、ドキュメントのみの更新

## Test plan
- [x] `python manage.py test subekashi.tests article.tests` で597件全て通過（ドキュメントのみの変更で挙動に影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)