### PR TITLE
[別名] 別名関連画面のナビゲーション導線を改善する

### DIFF
--- a/subekashi/static/subekashi/css/author.css
+++ b/subekashi/static/subekashi/css/author.css
@@ -20,6 +20,16 @@
     gap: 4px;
 }
 
+.dummybutton i {
+    margin-right: 10px;
+    font-size: 1.0em;
+}
+
+/* アイコンとテキストを上下中央寄せにする（共通のp{padding-top:5px}を打ち消す） */
+.dummybuttons .dummybutton p {
+    padding-top: 0;
+}
+
 #alias-count {
     font-size: 12px;
     color: #fff;

--- a/subekashi/static/subekashi/css/author.css
+++ b/subekashi/static/subekashi/css/author.css
@@ -20,11 +20,6 @@
     gap: 4px;
 }
 
-.dummybutton i {
-    margin-right: 10px;
-    font-size: 1.0em;
-}
-
 /* アイコンとテキストを上下中央寄せにする（共通のp{padding-top:5px}を打ち消す） */
 .dummybuttons .dummybutton p {
     padding-top: 0;

--- a/subekashi/static/subekashi/css/author_aliases.css
+++ b/subekashi/static/subekashi/css/author_aliases.css
@@ -38,11 +38,6 @@
     text-align: center;
 }
 
-.dummybutton i {
-    margin-right: 10px;
-    font-size: 1.0em;
-}
-
 /* アイコンとテキストを上下中央寄せにする（共通のp{padding-top:5px}を打ち消す） */
 .dummybuttons .dummybutton {
     align-items: center;

--- a/subekashi/static/subekashi/css/author_aliases.css
+++ b/subekashi/static/subekashi/css/author_aliases.css
@@ -73,8 +73,8 @@
 }
 
 /* .dummybutton単体と同じ詳細度(0,1,0)のため、確実に上書きするクラスの組み合わせにする */
-.dummybutton.dummybutton-w120 {
-    width: 120px;
+.dummybutton.dummybutton-w140 {
+    width: 140px;
 }
 
 /* disabled時、.dummybutton.black-dummybuttonの背景色(#333)が.dummybutton:disabledの
@@ -82,6 +82,11 @@
 .dummybutton.black-dummybutton:disabled {
     background-color: #666;
     cursor: not-allowed;
+}
+
+.dummybuttons .dummybutton:disabled p,
+.dummybuttons .dummybutton:disabled i {
+    color: #aaa;
 }
 
 #primary-name-song-list {

--- a/subekashi/static/subekashi/css/author_aliases.css
+++ b/subekashi/static/subekashi/css/author_aliases.css
@@ -73,7 +73,7 @@
 }
 
 /* .dummybutton単体と同じ詳細度(0,1,0)のため、確実に上書きするクラスの組み合わせにする */
-.dummybutton.primary-name-confirm-save {
+.dummybutton.dummybutton-w120 {
     width: 120px;
 }
 

--- a/subekashi/static/subekashi/css/common.css
+++ b/subekashi/static/subekashi/css/common.css
@@ -913,6 +913,13 @@ input[type=submit], button {
     padding-top: 5px;
 }
 
+/* アイコン付きdummybutton用の共通スタイル。author.css/author_aliases.css/
+   editor.css/song.cssで同一内容が個別に定義されていたため集約した */
+.dummybutton i {
+    margin-right: 10px;
+    font-size: 1.0em;
+}
+
 input[type=submit]:hover, button:hover, .dummybutton:hover {
     background-color: #fff;
 }

--- a/subekashi/static/subekashi/css/editor.css
+++ b/subekashi/static/subekashi/css/editor.css
@@ -7,11 +7,6 @@
     background-color: #666;
 }
 
-.dummybutton i {
-    margin-right: 10px;
-    font-size: 1.0em;
-}
-
 .dummybutton p {
     color: #fff;
     padding-bottom: 5px;

--- a/subekashi/static/subekashi/css/song.css
+++ b/subekashi/static/subekashi/css/song.css
@@ -6,11 +6,6 @@
     background-color: #666;
 }
 
-.dummybutton i {
-    margin-right: 10px;
-    font-size: 1.0em;
-}
-
 .dummybutton p {
     color: #fff;
     padding-top: 10px;

--- a/subekashi/static/subekashi/js/author_alias_form.js
+++ b/subekashi/static/subekashi/js/author_alias_form.js
@@ -1,6 +1,6 @@
 window.addEventListener('DOMContentLoaded', () => {
     const form = document.querySelector('form');
-    const submitButton = form.querySelector('input[type="submit"]');
+    const submitButton = form.querySelector('[type="submit"]');
     const aliasTypeSelect = document.getElementById('alias_type');
     const descriptionEl = document.getElementById('alias-type-description-text');
     const descriptionIconEl = document.getElementById('alias-type-description-icon');

--- a/subekashi/templates/subekashi/author.html
+++ b/subekashi/templates/subekashi/author.html
@@ -11,7 +11,7 @@
     <div class="dummybuttons">
         <div class="dummybutton-with-count">
             <a href="{% url 'subekashi:author_aliases' author_id %}">
-                <div class="dummybutton black-dummybutton"><p>別名</p></div>
+                <div class="dummybutton black-dummybutton"><i class="fas fa-people-arrows"></i><p>別名</p></div>
             </a>
             {% if alias_count >= 1 %}<p id="alias-count">{{ alias_count }}件の別名</p>{% endif %}
         </div>

--- a/subekashi/templates/subekashi/author_alias_edit.html
+++ b/subekashi/templates/subekashi/author_alias_edit.html
@@ -28,7 +28,7 @@
             <a href="{% url 'subekashi:author_aliases' author.id %}">
                 <div class="dummybutton black-dummybutton"><i class="fas fa-times"></i><p>戻る</p></div>
             </a>
-            <button type="submit" class="dummybutton black-dummybutton dummybutton-w120"><i class="fas fa-check"></i><p>更新する</p></button>
+            <button type="submit" class="dummybutton black-dummybutton dummybutton-w140"><i class="fas fa-check"></i><p>更新する</p></button>
         </div>
     </form>
 </section>

--- a/subekashi/templates/subekashi/author_alias_edit.html
+++ b/subekashi/templates/subekashi/author_alias_edit.html
@@ -24,7 +24,12 @@
         <p id="alias-type-description" class="alias-type-description info">
             <i id="alias-type-description-icon" class="fas fa-info-circle info"></i><span id="alias-type-description-text"></span>
         </p>
-        <input type="submit" value="更新">
+        <div class="dummybuttons">
+            <a href="{% url 'subekashi:author_aliases' author.id %}">
+                <div class="dummybutton black-dummybutton"><i class="fas fa-times"></i><p>戻る</p></div>
+            </a>
+            <button type="submit" class="dummybutton black-dummybutton dummybutton-w120"><i class="fas fa-check"></i><p>更新する</p></button>
+        </div>
     </form>
 </section>
 {% endblock %}

--- a/subekashi/templates/subekashi/author_aliases.html
+++ b/subekashi/templates/subekashi/author_aliases.html
@@ -24,6 +24,9 @@
     {% endif %}
 
     <div class="dummybuttons">
+        <a href="{% url 'subekashi:author' author.id %}">
+            <div class="dummybutton black-dummybutton"><i class="fas fa-user-circle"></i><p>作者ページ</p></div>
+        </a>
         <a onclick="reloadPage()">
             <div class="dummybutton black-dummybutton"><i class="fas fa-redo"></i><p>再読み込み</p></div>
         </a>

--- a/subekashi/templates/subekashi/author_primary_name_confirm.html
+++ b/subekashi/templates/subekashi/author_primary_name_confirm.html
@@ -31,7 +31,7 @@
         </a>
         <form action="{% url 'subekashi:author_primary_name_set' author.id %}" method="POST" class="dummybutton-form">{% csrf_token %}
             <input type="hidden" name="name" value="{{ new_name }}">
-            <button type="submit" class="dummybutton black-dummybutton dummybutton-w120"><i class="fas fa-check"></i><p>変更する</p></button>
+            <button type="submit" class="dummybutton black-dummybutton dummybutton-w140"><i class="fas fa-check"></i><p>変更する</p></button>
         </form>
     </div>
 </section>

--- a/subekashi/templates/subekashi/author_primary_name_confirm.html
+++ b/subekashi/templates/subekashi/author_primary_name_confirm.html
@@ -31,7 +31,7 @@
         </a>
         <form action="{% url 'subekashi:author_primary_name_set' author.id %}" method="POST" class="dummybutton-form">{% csrf_token %}
             <input type="hidden" name="name" value="{{ new_name }}">
-            <button type="submit" class="dummybutton black-dummybutton primary-name-confirm-save"><i class="fas fa-check"></i><p>変更する</p></button>
+            <button type="submit" class="dummybutton black-dummybutton dummybutton-w120"><i class="fas fa-check"></i><p>変更する</p></button>
         </form>
     </div>
 </section>

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -483,8 +483,9 @@ DBアクセス（候補・衝突チェック）を伴うため `TestCase` を使
 | 正方向の別名あり (#992) | 別名を1件登録 | 「1件の別名」が表示される |
 | 逆方向の別名あり (#992) | 他authorが自分のnameと一致する別名を保持 | 「1件の別名」が表示される（正方向＋逆方向の合計） |
 | 推移的な件数 (#1007) | `past`で1ホップ先の別名がさらに`spell`の別名を持つ（2ホップ） | 「2件の別名」が表示される（`get_transitive_aliases()`の件数に合わせる） |
+| 別名ボタンのアイコン (#1024) | 正常アクセス | `fa-people-arrows`アイコンが含まれる |
 
-#### 7-8-1. `AuthorAliasesView` (`/authors/<id>/aliases`)（#992、#1007）
+#### 7-8-1. `AuthorAliasesView` (`/authors/<id>/aliases`)（#992、#1007、#1024）
 
 | テストケース | 条件 | 期待結果 |
 | --- | --- | --- |
@@ -502,6 +503,8 @@ DBアクセス（候補・衝突チェック）を伴うため `TestCase` を使
 | 逆方向の別名の遷移アイコン | 他authorが自分のnameと一致する別名を保持 | 編集できない代わりに、相手authorの別名一覧への遷移アイコン(`fa-arrow-right`)が表示される |
 | 遷移先author idが0の場合の遷移アイコン | 遷移先authorを`id=0`で作成 | テンプレートが`is not None`で判定しているため、`id=0`でも遷移アイコンが表示される（真偽値判定だと0がfalsyになり表示されなくなる） |
 | 一番有名な名義フォームの初期状態（#1029） | past別名が存在するauthorのGET | `#primary-name-submit`ボタンが`disabled`かつラベルは「変更する」（初期選択は現在の名義のままのため変更不要） |
+| 作者ページへの導線（#1024） | 正常アクセス | 作者自身のページ（`/authors/<id>/`）へのリンク（`href`属性完全一致で判定。`/authors/<id>/aliases/...`系の他リンクとの部分一致による誤検出を避けるため）が表示される |
+| 作者ページボタンの位置（#1024） | 正常アクセス | `.dummybuttons`内で「再読み込み」「別名を追加する」より前（DOM順で最初、一番左）に配置される |
 
 ##### 推移的関係解決の反映・遷移アイコン（#1007、#1019）
 
@@ -553,7 +556,7 @@ DBアクセス（候補・衝突チェック）を伴うため `TestCase` を使
 | 別名義(another)の説明文 (#1004) | GETリクエスト | 「公認」の旨が含まれる |
 | 以前の名称(past)の説明文 (#1029) | GETリクエスト | 一番有名な名義として選択できる旨（「一番有名な名義」）が含まれる |
 
-#### 7-8-3. `AuthorAliasEditView` (`/authors/<id>/aliases/<alias_id>/edit`)（#992）
+#### 7-8-3. `AuthorAliasEditView` (`/authors/<id>/aliases/<alias_id>/edit`)（#992、#1024）
 
 | テストケース | 条件 | 期待結果 |
 | --- | --- | --- |
@@ -571,6 +574,8 @@ DBアクセス（候補・衝突チェック）を伴うため `TestCase` を使
 | 現在のalias_typeが選択済み (#996) | GETリクエスト | 該当する`<option>`に`selected`が付与されている |
 | `alias_type`のプレースホルダー (#996) | GETリクエスト | `<option value="" disabled>選択してください</option>`が含まれる（selectedではない） |
 | author_alias_form.jsの読み込み (#996) | GETリクエスト | スクリプトタグが含まれる |
+| 別名一覧画面へ戻るボタン (#1024) | GETリクエスト | 別名一覧画面（`/authors/<id>/aliases/`）へのリンク（`href`属性完全一致で判定。このページ自体のフォームaction`/authors/<id>/aliases/<alias_id>/edit/`との部分一致による誤検出を避けるため）と「戻る」の文言が含まれる |
+| 更新ボタンのスタイル (#1024) | GETリクエスト | 更新ボタンが一番有名な名義の変更確認画面と同様の`dummybutton`形式（`<button type="submit" class="dummybutton black-dummybutton dummybutton-w120">`、幅120px）で「更新する」と表示され、「戻る」ボタンと同じ`.dummybuttons`内に並ぶ |
 
 #### 7-8-4. `AuthorAliasDeleteView` (`/authors/<id>/aliases/<alias_id>/delete`)（#992）
 
@@ -627,7 +632,7 @@ DBアクセス（候補・衝突チェック）を伴うため `TestCase` を使
 | 共著曲は重複表示されない | 同じSongがauthor・conflicting_author双方の共著になっている | そのSongタイトルは箇条書きに1回だけ表示される（`distinct()`によるSong単位の重複排除） |
 | 曲が10件以下の場合 | Songが10件以下 | 「全て表示」ボタン（`#primary-name-show-all-songs`）は表示されず、全曲が表示された状態になる |
 | 曲が11件以上の場合 | Songが11件以上 | 11件目以降が`class="primary-name-song-hidden"`で非表示になり、「全て表示」ボタンが表示される |
-| 保存ボタンのラベル・幅 | 確認画面の表示 | ボタンのラベルは「変更する」（「保存する」は含まれない）、`primary-name-confirm-save`クラス（width: 120px）が付与される |
+| 保存ボタンのラベル・幅 | 確認画面の表示 | ボタンのラベルは「変更する」（「保存する」は含まれない）、`dummybutton-w120`クラス（width: 120px。author_alias_edit.htmlの更新ボタンと共通のクラス）が付与される |
 | データを変更しない | GETリクエストのみ | `Author`・`AuthorAlias`等のデータは一切変更されない |
 
 #### 7-9. `ChannelView` (`/channel/<name>/`)

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -575,7 +575,7 @@ DBアクセス（候補・衝突チェック）を伴うため `TestCase` を使
 | `alias_type`のプレースホルダー (#996) | GETリクエスト | `<option value="" disabled>選択してください</option>`が含まれる（selectedではない） |
 | author_alias_form.jsの読み込み (#996) | GETリクエスト | スクリプトタグが含まれる |
 | 別名一覧画面へ戻るボタン (#1024) | GETリクエスト | 別名一覧画面（`/authors/<id>/aliases/`）へのリンク（`href`属性完全一致で判定。このページ自体のフォームaction`/authors/<id>/aliases/<alias_id>/edit/`との部分一致による誤検出を避けるため）と「戻る」の文言が含まれる |
-| 更新ボタンのスタイル (#1024) | GETリクエスト | 更新ボタンが一番有名な名義の変更確認画面と同様の`dummybutton`形式（`<button type="submit" class="dummybutton black-dummybutton dummybutton-w120">`、幅120px）で「更新する」と表示され、「戻る」ボタンと同じ`.dummybuttons`内に並ぶ |
+| 更新ボタンのスタイル (#1024) | GETリクエスト | 更新ボタンが一番有名な名義の変更確認画面と同様の`dummybutton`形式（`<button type="submit" class="dummybutton black-dummybutton dummybutton-w140">`、幅140px）で「更新する」と表示され、「戻る」ボタンと同じ`.dummybuttons`内に並ぶ |
 
 #### 7-8-4. `AuthorAliasDeleteView` (`/authors/<id>/aliases/<alias_id>/delete`)（#992）
 
@@ -632,7 +632,7 @@ DBアクセス（候補・衝突チェック）を伴うため `TestCase` を使
 | 共著曲は重複表示されない | 同じSongがauthor・conflicting_author双方の共著になっている | そのSongタイトルは箇条書きに1回だけ表示される（`distinct()`によるSong単位の重複排除） |
 | 曲が10件以下の場合 | Songが10件以下 | 「全て表示」ボタン（`#primary-name-show-all-songs`）は表示されず、全曲が表示された状態になる |
 | 曲が11件以上の場合 | Songが11件以上 | 11件目以降が`class="primary-name-song-hidden"`で非表示になり、「全て表示」ボタンが表示される |
-| 保存ボタンのラベル・幅 | 確認画面の表示 | ボタンのラベルは「変更する」（「保存する」は含まれない）、`dummybutton-w120`クラス（width: 120px。author_alias_edit.htmlの更新ボタンと共通のクラス）が付与される |
+| 保存ボタンのラベル・幅 | 確認画面の表示 | ボタンのラベルは「変更する」（「保存する」は含まれない）、`dummybutton-w140`クラス（width: 140px。author_alias_edit.htmlの更新ボタンと共通のクラス）が付与される |
 | データを変更しない | GETリクエストのみ | `Author`・`AuthorAlias`等のデータは一切変更されない |
 
 #### 7-9. `ChannelView` (`/channel/<name>/`)

--- a/subekashi/tests/test_views.py
+++ b/subekashi/tests/test_views.py
@@ -462,6 +462,11 @@ class AuthorViewTest(TestCase):
         self.assertContains(response, reverse("subekashi:author_aliases", args=[self.author.id]))
         self.assertNotContains(response, "件の別名")
 
+    def test_alias_link_has_icon(self):
+        # 別名ボタンにfa-people-arrowsアイコンを表示する（#1024）
+        response = self.client.get(reverse("subekashi:author", args=[self.author.id]))
+        self.assertContains(response, "fa-people-arrows")
+
     def test_alias_count_shown_when_forward_alias_exists(self):
         AuthorAlias.objects.create(name="件数テスト別名", author=self.author, alias_type="past")
         response = self.client.get(reverse("subekashi:author", args=[self.author.id]))
@@ -502,6 +507,23 @@ class AuthorAliasesViewTest(TestCase):
         response = self.client.get(reverse("subekashi:author_aliases", args=[self.author.id]))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "別名が見つかりませんでした")
+
+    def test_author_page_link_is_present(self):
+        # 別名一覧画面から作者自身のページへ遷移できるボタンを表示する（#1024）。
+        # reverse("subekashi:author", ...)は"/authors/<id>/aliases/..."等の他リンクの
+        # プレフィックスとしても部分一致してしまうため、ボタンのラベルで判定する
+        response = self.client.get(reverse("subekashi:author_aliases", args=[self.author.id]))
+        author_url = reverse("subekashi:author", args=[self.author.id])
+        self.assertContains(response, f'href="{author_url}"')
+        self.assertContains(response, "作者ページ")
+
+    def test_author_page_link_is_leftmost_button(self):
+        # 作者ページボタンは.dummybuttons内の一番左（DOM順で最初）に配置する（#1024）
+        response = self.client.get(reverse("subekashi:author_aliases", args=[self.author.id]))
+        content = response.content.decode()
+        author_url = reverse("subekashi:author", args=[self.author.id])
+        self.assertLess(content.index(f'href="{author_url}"'), content.index("再読み込み"))
+        self.assertLess(content.index(f'href="{author_url}"'), content.index("別名を追加する"))
 
     def test_forward_alias_is_displayed_with_edit_delete_links(self):
         alias = AuthorAlias.objects.create(name="別名X", author=self.author, alias_type="spell")
@@ -915,6 +937,26 @@ class AuthorAliasEditViewTest(TestCase):
         )
         self.assertContains(response, 'value="past" data-description="以前使用されていた名称です。')
         self.assertContains(response, 'selected>以前の名称</option>')
+
+    def test_back_to_alias_list_button_is_present(self):
+        # 別名一覧画面へ戻るボタンを表示する（#1024）。
+        # reverse("subekashi:author_aliases", ...)は、このページ自体のフォームaction
+        # ("/authors/<id>/aliases/<alias_id>/edit/")のプレフィックスとしても部分一致
+        # してしまうため、href属性値として厳密に一致するかで判定する
+        response = self.client.get(
+            reverse("subekashi:author_alias_edit", args=[self.author.id, self.alias.id])
+        )
+        aliases_url = reverse("subekashi:author_aliases", args=[self.author.id])
+        self.assertContains(response, f'href="{aliases_url}"')
+        self.assertContains(response, "戻る")
+
+    def test_submit_button_matches_confirm_screen_style(self):
+        # 更新ボタンを一番有名な名義の変更確認画面と同様のdummybutton形式にする（#1024）
+        response = self.client.get(
+            reverse("subekashi:author_alias_edit", args=[self.author.id, self.alias.id])
+        )
+        self.assertContains(response, "更新する")
+        self.assertContains(response, '<button type="submit" class="dummybutton black-dummybutton dummybutton-w120">')
 
     def test_alias_type_has_disabled_placeholder_option(self):
         response = self.client.get(
@@ -1573,7 +1615,7 @@ class AuthorPrimaryNameConfirmViewTest(TestCase):
             reverse("subekashi:author_primary_name_confirm", args=[self.author.id]), {"name": "以前の名義"}
         )
         self.assertContains(response, "変更する")
-        self.assertContains(response, "primary-name-confirm-save")
+        self.assertContains(response, "dummybutton-w120")
         self.assertNotContains(response, "保存する")
 
     def test_show_all_songs_button_hidden_when_ten_or_fewer_songs(self):

--- a/subekashi/tests/test_views.py
+++ b/subekashi/tests/test_views.py
@@ -956,7 +956,7 @@ class AuthorAliasEditViewTest(TestCase):
             reverse("subekashi:author_alias_edit", args=[self.author.id, self.alias.id])
         )
         self.assertContains(response, "更新する")
-        self.assertContains(response, '<button type="submit" class="dummybutton black-dummybutton dummybutton-w120">')
+        self.assertContains(response, '<button type="submit" class="dummybutton black-dummybutton dummybutton-w140">')
 
     def test_alias_type_has_disabled_placeholder_option(self):
         response = self.client.get(
@@ -1615,7 +1615,7 @@ class AuthorPrimaryNameConfirmViewTest(TestCase):
             reverse("subekashi:author_primary_name_confirm", args=[self.author.id]), {"name": "以前の名義"}
         )
         self.assertContains(response, "変更する")
-        self.assertContains(response, "dummybutton-w120")
+        self.assertContains(response, "dummybutton-w140")
         self.assertNotContains(response, "保存する")
 
     def test_show_all_songs_button_hidden_when_ten_or_fewer_songs(self):


### PR DESCRIPTION
## Summary
- author.htmlの「別名」ボタンに`fa-people-arrows`アイコンを追加し、アイコンとテキストの上下中央寄せ・間隔を他ページの`.dummybutton`と揃えた
- author_aliases.htmlの`.dummybuttons`に、作者自身のページへ遷移するボタンを一番左に追加
- author_alias_edit.htmlに別名一覧画面へ戻るボタンを追加し、更新ボタンも一番有名な名義の変更確認画面と同様のdummybutton形式・幅140px（`dummybutton-w140`共通クラス）に統一
- disabled状態のボタンの背景色・文字色（p・i要素）が正しく適用されるようCSSの詳細度を調整

Closes #1024

## Test plan
- [x] `python manage.py test subekashi.tests article.tests` で602件全て通過
- [x] 追加した各要素は一時的にロジックを無効化してテストが失敗することを確認した上で復元
- [x] `TEST_PLAN_UNIT.md` を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)