### PR TITLE
デプロイ時のcollectstaticに--clearオプションを追加

### DIFF
--- a/subekashi/management/commands/deploy.py
+++ b/subekashi/management/commands/deploy.py
@@ -16,7 +16,7 @@ class Command(BaseCommand) :
         COMMANDS = [
             "git pull origin main",
             "pip install -r requirements.txt",
-            "python manage.py collectstatic --noinput",
+            "python manage.py collectstatic --noinput --clear",
             "python manage.py appversion"
         ]
         if not options['no_migrate']:


### PR DESCRIPTION
## Summary
- `subekashi/management/commands/deploy.py` の `collectstatic` 実行コマンドに `--clear` オプションを追加

## 背景
`ManifestStaticFilesStorage` はファイル内容のハッシュ値をファイル名に含めて配信するため、`--clear` を付けずに `collectstatic` を実行すると、内容が変わった静的ファイルの「古いハッシュ名のコピー」が削除されずに `STATIC_ROOT` に残り続けていた。このリポジトリはPRの統合頻度が高いため、デプロイのたびに古いファイルが積み上がりディスク使用量が線形に増加していた。

`STATIC_ROOT` は完全にビルド生成物であり毎回再生成されるため、`--clear` によるデータ損失リスクはない。

## テストについて
`deploy` コマンドは `subprocess` 経由で外部コマンド(git pull, pip install, collectstatic等)やPythonAnywhere APIを呼び出す運用コマンドであり、既存のテストも存在しないため、今回は文字列変更のみで新規テストは追加していません。

## Test plan
- [ ] 次回デプロイ後、PythonAnywhere上で `static/` ディレクトリの使用容量が想定通り増加しなくなることを確認する
- [ ] 既存の肥大化した `static/` ディレクトリについても、次回デプロイ時に不要な古いファイルが削除されることを確認する

Closes #1028

🤖 Generated with [Claude Code](https://claude.com/claude-code)