### PR TITLE
トップニュースのhandle_as_news記事にDefaultArticleViewへのリンクを付与

### DIFF
--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -396,6 +396,10 @@ DBアクセス（候補・衝突チェック）を伴うため `TestCase` を使
 | --- | --- | --- |
 | 正常アクセス | GETリクエスト | HTTP 200 |
 | テンプレートが使用される | GETリクエスト | `subekashi/top.html` がレンダリングされる |
+| ニュース欄のリンク付与（#961） | `tag="news"`, `handle_as_news=False`の記事 | タイトルのみ表示され`<a>`タグは付与されない |
+| ニュース欄のリンク付与（#961） | `tag="release"`の記事 | `DefaultArticleView`へのURLでタイトル全体が`<a>`タグにくくられる |
+| ニュース欄のリンク付与（#961） | `handle_as_news=True`の記事（`tag`は`news`以外） | `DefaultArticleView`へのURLでタイトル全体が`<a>`タグにくくられる |
+| ニュース欄のリンク付与（#961） | `tag="news"`かつ`handle_as_news=True`の記事 | `handle_as_news`が優先され、リンクが付与される |
 
 #### 7-2. `SongsView` (`/songs/`)
 

--- a/subekashi/tests/test_views.py
+++ b/subekashi/tests/test_views.py
@@ -9,6 +9,8 @@ from django.db import connection
 from django.test import TestCase, Client, override_settings
 from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
+from django.utils import timezone
+from article.models import Article
 from subekashi.forms import AuthorAliasForm
 from subekashi.models import Ad, Author, AuthorAlias, AuthorLink, Contact, Editor, History, Song
 
@@ -26,6 +28,45 @@ class TopViewTest(TestCase):
     def test_get_returns_200(self):
         response = self.client.get(reverse("subekashi:top"))
         self.assertEqual(response.status_code, 200)
+
+    def test_news_tag_article_has_no_link(self):
+        """tag=newsかつhandle_as_news=Falseの記事はリンクされずタイトルのみ表示される"""
+        Article.objects.create(
+            article_id="news-1", title="通常ニュース", tag="news",
+            post_time=timezone.now(), is_open=True,
+        )
+        response = self.client.get(reverse("subekashi:top"))
+        self.assertContains(response, "<span>通常ニュース</span>")
+
+    def test_release_tag_article_has_link(self):
+        """tag=releaseの記事はDefaultArticleViewへのリンクでタイトル全体がくくられる"""
+        article = Article.objects.create(
+            article_id="release-1", title="リリース記事", tag="release",
+            post_time=timezone.now(), is_open=True,
+        )
+        response = self.client.get(reverse("subekashi:top"))
+        url = reverse("article:default_article", args=[article.article_id])
+        self.assertContains(response, f"<span><a href='{url}'>リリース記事</a></span>")
+
+    def test_handle_as_news_article_has_link(self):
+        """handle_as_news=Trueの記事はtagに関わらずDefaultArticleViewへのリンクでタイトル全体がくくられる"""
+        article = Article.objects.create(
+            article_id="blog-as-news", title="ニュース扱いブログ", tag="blog",
+            post_time=timezone.now(), is_open=True, handle_as_news=True,
+        )
+        response = self.client.get(reverse("subekashi:top"))
+        url = reverse("article:default_article", args=[article.article_id])
+        self.assertContains(response, f"<span><a href='{url}'>ニュース扱いブログ</a></span>")
+
+    def test_news_tag_with_handle_as_news_has_link(self):
+        """tag=newsでもhandle_as_news=Trueならリンクされる"""
+        article = Article.objects.create(
+            article_id="news-as-news", title="扱い指定ニュース", tag="news",
+            post_time=timezone.now(), is_open=True, handle_as_news=True,
+        )
+        response = self.client.get(reverse("subekashi:top"))
+        url = reverse("article:default_article", args=[article.article_id])
+        self.assertContains(response, f"<span><a href='{url}'>扱い指定ニュース</a></span>")
 
 
 @override_settings(STATICFILES_STORAGE=STATIC_STORAGE)

--- a/subekashi/views/top.py
+++ b/subekashi/views/top.py
@@ -31,8 +31,12 @@ class TopView(View):
 
         news_htmls = ""
         for article in article_qs:
-            is_news = article.tag == "news"
-            news_html = article.title if is_news else f"<a href='/articles/{article.article_id}'>{article.title}</a>"
+            should_link = article.handle_as_news or article.tag != "news"
+            if should_link:
+                article_url = reverse('article:default_article', args=[article.article_id])
+                news_html = f"<a href='{article_url}'>{article.title}</a>"
+            else:
+                news_html = article.title
             news_htmls += f"<span>{news_html}</span>"
         context["news_htmls"] = news_htmls
 


### PR DESCRIPTION
## Summary
- `subekashi/views/top.py`: `handle_as_news=True`の記事は`tag`に関わらず、DefaultArticleViewへのリンクでtitle要素全体をくくるよう修正。従来は`tag=="news"`かどうかのみでリンク有無を判定していたため、`tag="news"`かつ`handle_as_news=True`の記事にリンクが付かないバグがあった。
- ハードコードされていたURL文字列(`/articles/{id}`)を`reverse('article:default_article', ...)`に変更。
- 上記挙動を検証するテストを`subekashi/tests/test_views.py`に4件追加。
- `subekashi/tests/TEST_PLAN_UNIT.md`のTopViewセクションを更新。

Closes #961

## Test plan
- [x] `python manage.py test subekashi.tests article.tests` (610件) が全てパスすることを確認