### PR TITLE
fix: reason指定時にSongEditViewの削除フォームへ自動スクロール

### DIFF
--- a/subekashi/static/subekashi/js/song_edit.js
+++ b/subekashi/static/subekashi/js/song_edit.js
@@ -35,6 +35,7 @@ function openDeleteDetails() {
     const details = document.getElementById('delete-details');
     if (details) {
       details.open = true;
+      details.scrollIntoView();
     }
   }
 }


### PR DESCRIPTION
## Summary
- `?reason=`パラメータ付きでSongEditViewにアクセスした際、削除申請の詳細(`<details id="delete-details">`)が開いた後、その要素まで自動スクロールするようにした
- 削除申請の展開自体は既存実装（#615）で対応済みだったため、今回はスクロール処理のみ追加

## Test plan
- [x] JSのUI変更のみのため、既存Pythonテスト(`python manage.py test subekashi.tests article.tests`)への影響なし
- [ ] ブラウザで `/songs/<id>/edit?reason=xxx` にアクセスし、削除申請が開いた状態でその位置までスクロールされることを確認

Closes #1010

🤖 Generated with [Claude Code](https://claude.com/claude-code)