### PR TITLE
fix: 複数URL登録済みの曲でallow_dup許可時に他のURLが消える不具合を修正

### DIFF
--- a/subekashi/static/subekashi/js/song_edit.js
+++ b/subekashi/static/subekashi/js/song_edit.js
@@ -6,7 +6,14 @@ async function init() {
     openDeleteDetails();
     song_id = window.location.pathname.split("/")[2];
     const allowDupUrl = new URLSearchParams(window.location.search).get('allow_dup_url');
-    if (allowDupUrl) document.getElementById('url').value = allowDupUrl;
+    if (allowDupUrl) {
+        const urlInputEle = document.getElementById('url');
+        const existingUrls = urlInputEle.value ? urlInputEle.value.split(',').filter(Boolean) : [];
+        if (!existingUrls.includes(allowDupUrl)) {
+            existingUrls.push(allowDupUrl);
+        }
+        urlInputEle.value = existingUrls.join(',');
+    }
 
     const params = new URLSearchParams({ song_id });
     if (titleEle.value) params.append('title', titleEle.value);


### PR DESCRIPTION
## Summary
- `song_edit.js` の `init()` が `allow_dup_url` クエリパラメータの値で `#url` フィールドを**上書き**していたため、複数のURLを登録している曲で重複許可リンク（「複数の曲があるURLとして登録したい場合、こちらをクリックしてください」）をクリックすると、他の登録済みURLが入力欄から消えていた
- そのまま保存すると、意図せず他のURLが曲から削除されてしまう
- `allow_dup_url` の値を既存URLリストに追加（重複していれば追加しない）する形に修正

## 調査内容
- バックエンド側（`validate_song_url`、`SongLinkAPI`、`song_edit_init`、実際の編集POSTフロー）は複数URL登録済みの曲でも正しく重複判定できることをテストで確認済み（今回の不具合はフロントエンド限定）
- 既存のPythonテストスイート（610件）に影響なし、全てパス
- 修正後のJSロジックをNode.jsで動作検証（既存URL保持・空欄からの新規URL設定・重複追加防止の3パターン）
- 実データ（song_id=9358）で手動確認用のセットアップを実施し、動作を確認

## Test plan
- [x] `python manage.py test subekashi.tests article.tests` が全件パスすることを確認
- [x] Node.jsで修正後のURLマージロジックの単体動作を確認
- [ ] ブラウザで実際に複数URL登録済みの曲を編集し、重複許可リンククリック後もURLが保持されることを目視確認（本プロジェクトにはJS/ブラウザの自動テスト基盤が存在しないため）

Closes #885

🤖 Generated with [Claude Code](https://claude.com/claude-code)