### PR TITLE
fix: allow_dup URL追加時の重複判定を正規化後の値で比較するよう修正

### DIFF
--- a/subekashi/static/subekashi/js/song_edit.js
+++ b/subekashi/static/subekashi/js/song_edit.js
@@ -1,5 +1,13 @@
 var imitateIdList = [], songGuesserController, song_id;
 
+// URLの表記揺れを正規化する（重複判定・#url反映で共通利用）
+function normalizeSongUrl(url) {
+    url = url.replace("https://www.google.com/url?q=", "");
+    url = url.replace("https://www.", "https://");
+    url = url.replace("https://twitter.com", "https://x.com");
+    return formatYouTubeURL(url);
+}
+
 // 初期化
 const lyricsEle = document.getElementById("lyrics")
 async function init() {
@@ -9,7 +17,10 @@ async function init() {
     if (allowDupUrl) {
         const urlInputEle = document.getElementById('url');
         const existingUrls = urlInputEle.value ? urlInputEle.value.split(',').filter(Boolean) : [];
-        if (!existingUrls.includes(allowDupUrl)) {
+        // 既存URLも同じ正規化を通してから比較し、表記揺れによる誤った重複追加を防ぐ
+        const normalizedAllowDupUrl = normalizeSongUrl(allowDupUrl);
+        const alreadyExists = existingUrls.some(u => normalizeSongUrl(u) === normalizedAllowDupUrl);
+        if (!alreadyExists) {
             existingUrls.push(allowDupUrl);
         }
         urlInputEle.value = existingUrls.join(',');
@@ -281,10 +292,7 @@ async function checkUrlForm(prefetchedLinks = undefined) {
         }
 
         // URLのフォーマット
-        url = url.replace("https://www.google.com/url?q=", "");
-        url = url.replace("https://www.", "https://");
-        url = url.replace("https://twitter.com", "https://x.com");
-        url = formatYouTubeURL(url);
+        url = normalizeSongUrl(url);
 
         // イテレーションごとに固有のfromキーを使い、ループ間のスロットル干渉を防ぐ
         let links;


### PR DESCRIPTION
## Summary
- #885 の修正（PR #1040）で `song_edit.js` に導入した「allow_dup許可URLを既存URLリストに追加する」処理は、重複判定が完全一致の文字列比較だった
- `allowDupUrl` は `checkUrlForm` 側で正規化（`www.` 除去、`twitter.com`→`x.com`、YouTube URL短縮）済みの値である一方、`#url` に元から入っている既存URL（DBの `SongLink.url`）は正規化ルールが後から追加された場合など古い表記のまま残っている可能性があり、実質同一URLでも文字列不一致により重複として `#url` に二重追加されてしまう可能性があった
- `checkUrlForm` 内にあったURL正規化処理を `normalizeSongUrl()` として共通化し、`allowDupUrl` と既存URL両方に適用してから比較するよう修正

## Test plan
- [x] `python manage.py test subekashi.tests article.tests` が610件全てパスすることを確認（JS変更のみのため無影響）
- [x] Node.jsで正規化＋重複判定ロジックを検証：
  - 複数URL登録済みの曲への新規URL追加（#885のケース）
  - `www.youtube.com` 形式の旧データと正規化後URLの重複判定
  - `twitter.com` 形式の旧データと `x.com` 正規化後URLの重複判定
  - 完全一致の重複、空欄からの新規追加、いずれも従来通りの挙動を維持

Fixes #1041
関連: #885, PR #1040

🤖 Generated with [Claude Code](https://claude.com/claude-code)