### PR TITLE
[Delete] ローカルバックアップ用backups/フォルダの削除（#1065）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,6 @@ wordcloud.py
 sitemap.xml
 .env
 sandbox
-backups/*
-!backups/
-!backups/.gitkeep
 private/*
 dynamic/*
 subekashi/constants/dynamic/*


### PR DESCRIPTION
## Summary
- #1050でバックアップ先がサーバーローカル保存からGoogle Driveへ移行済みだったが、旧仕様の名残であるローカル`backups/`フォルダ（`.gitkeep`）と`.gitignore`の関連エントリ（`backups/*` / `!backups/` / `!backups/.gitkeep`）が未削除だったため削除
- `backup.py`本体・`lib/google_drive.py`・関連テスト・テスト計画書はすでにGoogle Drive方式のみを反映済みで、他に古い仕様のコード・テストは見つからなかった

Closes #1065

## Test plan
- [x] `python manage.py test subekashi.tests article.tests` — 642件全てパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)