### PR TITLE
[Fix] sort=upload_time時にupload_time=nullの曲を除外

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ python manage.py runserver
 - YouTube関連のフィルタ（view, like, upload_time）やソートを使用する場合、`mediatypes`を指定しない限り、自動的にYouTube動画のみに絞り込まれます
 - view関連のフィルタまたはソートを使用する場合、view >= 1 の曲のみが対象となります
 - like関連のフィルタまたはソートを使用する場合、like >= 1 の曲のみが対象となります
+- sort=upload_time / sort=-upload_time を使用する場合、upload_time が null の曲は結果から除外されます
 - view、likeの値は1以上の整数のみ受け付けます。0以下の値を指定するとバリデーションエラーが発生します
 - バリデーションエラーが発生した場合、400 Bad Requestと共にエラーメッセージが返されます
 

--- a/subekashi/lib/song_filterset.py
+++ b/subekashi/lib/song_filterset.py
@@ -230,9 +230,14 @@ class SongFilter(django_filters.FilterSet):
             queryset = queryset.filter(filter_by_mediatypes('youtube'))
 
         # upload_timeソートがある場合、mediatypes=youtubeを明示的に適用
-        upload_time_youtube_applied = has_upload_time_sort(self.data) and 'mediatypes' not in self.data
+        has_upload_time_sort_value = has_upload_time_sort(self.data)
+        upload_time_youtube_applied = has_upload_time_sort_value and 'mediatypes' not in self.data
         if upload_time_youtube_applied:
             queryset = queryset.filter(filter_by_mediatypes('youtube'))
+
+        # upload_timeソートがある場合、upload_time が null の曲を除外
+        if has_upload_time_sort_value:
+            queryset = queryset.filter(upload_time__isnull=False)
 
         # view関連のフィルタまたはソートがある場合、view >= 1 を適用
         if has_view_filter_or_sort(self.data):

--- a/subekashi/tests/test_lib_song_search.py
+++ b/subekashi/tests/test_lib_song_search.py
@@ -187,6 +187,36 @@ class SongSearchSortViewWithFilterTest(TestCase):
         self.assertEqual(views, [300, 200, 100])
 
 
+class SongSearchSortUploadTimeExcludesNullTest(TestCase):
+    """sort=upload_time / sort=-upload_time 使用時に upload_time が null の曲を除外するテスト（issue #1072）"""
+
+    def setUp(self):
+        self.with_time = Song.objects.create(
+            title="共通ワードUpload時刻あり",
+            upload_time=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )
+        link = SongLink.objects.create(url="https://youtu.be/uploadtimetest01")
+        link.songs.add(self.with_time)
+
+        self.without_time = Song.objects.create(title="共通ワードUpload時刻なし")
+        link2 = SongLink.objects.create(url="https://youtu.be/uploadtimetest02")
+        link2.songs.add(self.without_time)
+
+    def test_sort_upload_time_asc_excludes_null(self):
+        qs, stats = song_search({"keyword": "共通ワード", "sort": "upload_time", "size": "100"})
+        song_ids = [s.id for s in qs]
+        self.assertEqual(stats["count"], 1)
+        self.assertIn(self.with_time.id, song_ids)
+        self.assertNotIn(self.without_time.id, song_ids)
+
+    def test_sort_upload_time_desc_excludes_null(self):
+        qs, stats = song_search({"keyword": "共通ワード", "sort": "-upload_time", "size": "100"})
+        song_ids = [s.id for s in qs]
+        self.assertEqual(stats["count"], 1)
+        self.assertIn(self.with_time.id, song_ids)
+        self.assertNotIn(self.without_time.id, song_ids)
+
+
 class SongSearchSortWithAuthorFilterTest(TestCase):
     """author フィルターと sort の組み合わせテスト（author も distinct() を引き起こす）"""
 


### PR DESCRIPTION
## Summary
- `sort=upload_time` / `sort=-upload_time` を使用した場合に、`upload_time` が `null` の曲を結果から除外するよう修正
- view/likeソート時の `view >= 1` / `like >= 1` 除外と同様のパターンで、`song_filterset.py` の `qs` プロパティに `upload_time__isnull=False` フィルタを追加
- README のAPI仕様（注意事項）にこの挙動を追記

## Test plan
- [x] `SongSearchSortUploadTimeExcludesNullTest` を追加し、昇順・降順どちらでも `upload_time=null` の曲が除外されることを検証
- [x] `python manage.py test subekashi.tests article.tests` （726件）が全てパスすることを確認

Closes #1072

🤖 Generated with [Claude Code](https://claude.com/claude-code)