### PR TITLE
[Fix] SPフッターメニューの歌詞作成(/ai/)を統計(/stats/)に変更

### DIFF
--- a/subekashi/templates/subekashi/base/sp_menu.html
+++ b/subekashi/templates/subekashi/base/sp_menu.html
@@ -24,6 +24,6 @@
     <a href="{% url 'subekashi:top' %}"><i class="fas fa-home"></i></a>
     <a href="{% url 'subekashi:song_new' %}"><i class="fa fa-plus"></i></a>
     <a href="{% url 'subekashi:songs' %}"><i class="fas fa-search"></i></a>
-    <a href="{% url 'subekashi:ai' %}"><i class="fas fa-align-center"></i></a>
+    <a href="{% url 'subekashi:stats' %}"><i class="fas fa-chart-line"></i></a>
     <i class="fas fa-bars" id="toggle-tab-bar"></i>
 </div>


### PR DESCRIPTION
## Summary
- SPフッターメニュー（tab_bar）の /ai/（歌詞作成）へのリンクを /stats/（統計）へのリンクに変更
- アイコンも歌詞作成用（fa-align-center）から統計用（fa-chart-line、他のASIDE_PAGES定義と統一）に変更

## Test plan
- [x] `python manage.py test subekashi.tests.test_views` が全件成功することを確認
- [x] 静的なテンプレート変更（ハードコードされたURL/アイコンの差し替え）のみのため、新規テストは追加せず

Closes #1077

🤖 Generated with [Claude Code](https://claude.com/claude-code)