### PR TITLE
[Fix] ai_resultの評価選択肢を.range-radio-groupに変更

### DIFF
--- a/subekashi/static/subekashi/css/ai_result.css
+++ b/subekashi/static/subekashi/css/ai_result.css
@@ -15,21 +15,6 @@
     }
 }
 
-.evaluation {
-    display: inline-block;
-}
-
-.evaluation label {
-    margin-right: 15px;
-    cursor: pointer;
-}
-
-.score {
-    box-shadow: none;
-    height: 15px;
-    width: 15px;
-}
-
 #ai-result-form {
     margin-top: 40px;
 }

--- a/subekashi/templates/subekashi/ai_result.html
+++ b/subekashi/templates/subekashi/ai_result.html
@@ -10,16 +10,16 @@
     {% for aiIns in aiInsL  %}
         <div class="ai-ins">
             {% include "subekashi/components/lyric_tokens.html" with item=aiIns %}
-            <div class="evaluation">
-                <input type="radio" id="{{ aiIns.id }}1" class="score" name="radio{{ aiIns.id }}" oninput="setScore('{{ aiIns.id }}', 1)">
+            <div class="range-radio-group">
+                <input type="radio" id="{{ aiIns.id }}1" name="radio{{ aiIns.id }}" oninput="setScore('{{ aiIns.id }}', 1)">
                 <label for="{{ aiIns.id }}1">悪い</label>
-                <input type="radio" id="{{ aiIns.id }}2" class="score" name="radio{{ aiIns.id }}" oninput="setScore('{{ aiIns.id }}', 2)">
+                <input type="radio" id="{{ aiIns.id }}2" name="radio{{ aiIns.id }}" oninput="setScore('{{ aiIns.id }}', 2)">
                 <label for="{{ aiIns.id }}2">微妙</label>
-                <input type="radio" id="{{ aiIns.id }}3" class="score" name="radio{{ aiIns.id }}" oninput="setScore('{{ aiIns.id }}', 3)">
+                <input type="radio" id="{{ aiIns.id }}3" name="radio{{ aiIns.id }}" oninput="setScore('{{ aiIns.id }}', 3)">
                 <label for="{{ aiIns.id }}3">普通</label>
-                <input type="radio" id="{{ aiIns.id }}4" class="score" name="radio{{ aiIns.id }}" oninput="setScore('{{ aiIns.id }}', 4)">
+                <input type="radio" id="{{ aiIns.id }}4" name="radio{{ aiIns.id }}" oninput="setScore('{{ aiIns.id }}', 4)">
                 <label for="{{ aiIns.id }}4">良い</label>
-                <input type="radio" id="{{ aiIns.id }}5" class="score" name="radio{{ aiIns.id }}" oninput="setScore('{{ aiIns.id }}', 5)">
+                <input type="radio" id="{{ aiIns.id }}5" name="radio{{ aiIns.id }}" oninput="setScore('{{ aiIns.id }}', 5)">
                 <label for="{{ aiIns.id }}5">最高</label>
             </div>
         </div>


### PR DESCRIPTION
## 概要
- 歌詞作成結果ページ（/ai/result/）の評価用ラジオボタン（悪い/微妙/普通/良い/最高）を、statsページ等で使用している `.range-radio-group`（common.css）のピル型スタイルに統一
- 独自定義だった `.evaluation` / `.score` の旧スタイルは不要になったため削除
- スコア送信処理（setScore）・「最高の行をコピー」処理（copyBest、DOM順序に依存）には影響がないことを確認

## テスト計画
- [x] `python manage.py test subekashi.tests article.tests` を実行し、既存の879テストが全てパスすることを確認
- 見た目のみの変更でロジック変更を伴わないため、新規テストは追加していません

closes #1076

🤖 Generated with [Claude Code](https://claude.com/claude-code)