### PR TITLE
MySQL移行に向けた文字列長バリデーションの欠落を修正

### DIFF
--- a/subekashi/forms.py
+++ b/subekashi/forms.py
@@ -119,6 +119,9 @@ class SongEditForm(forms.Form):
         max_length=500,
         error_messages={'required': 'タイトルが未入力です。'},
     )
+    # authors・urlはカンマ区切りで複数値を受け付けるため、フォーム全体へのmax_length指定は
+    # 個々の値の長さを正しく制限できない（分割後の各値の長さはview側で個別に検証している。
+    # authors→validate_author_name_lengths()、url→validate_song_url()、#1085）
     authors = forms.CharField(
         error_messages={'required': '作者は空白にできません。'},
     )

--- a/subekashi/forms.py
+++ b/subekashi/forms.py
@@ -21,6 +21,7 @@ class ContactForm(forms.Form):
     )
     detail = forms.CharField(
         widget=forms.Textarea,
+        max_length=10000,
         error_messages={'required': '入力必須項目を入力してください。'},
     )
 
@@ -123,7 +124,7 @@ class SongEditForm(forms.Form):
     )
     url = forms.CharField(required=False)
     imitate = forms.CharField(required=False)
-    lyrics = forms.CharField(required=False, widget=forms.Textarea)
+    lyrics = forms.CharField(required=False, max_length=10000, widget=forms.Textarea)
     is_original = forms.BooleanField(required=False)
     is_deleted = forms.BooleanField(required=False)
     is_joke = forms.BooleanField(required=False)

--- a/subekashi/lib/author_helpers.py
+++ b/subekashi/lib/author_helpers.py
@@ -8,6 +8,15 @@ def _non_empty_names(author_names):
     return [name for name in author_names if name]  # 空文字列をスキップ
 
 
+def validate_author_name_lengths(author_names):
+    """作者名の長さを検証する。上限を超えるものがあればエラーメッセージを返す。問題なければNone。"""
+    max_length = Author._meta.get_field('name').max_length
+    for name in _non_empty_names(author_names):
+        if len(name) > max_length:
+            return f"作者名は{max_length}文字以下である必要があります：{name}"
+    return None
+
+
 def get_or_create_authors(author_names):
     """
     作者名のリストからAuthorオブジェクトのリストを返す

--- a/subekashi/lib/author_helpers.py
+++ b/subekashi/lib/author_helpers.py
@@ -9,11 +9,18 @@ def _non_empty_names(author_names):
 
 
 def validate_author_name_lengths(author_names):
-    """作者名の長さを検証する。上限を超えるものがあればエラーメッセージを返す。問題なければNone。"""
+    """作者名の長さを検証する。上限を超えるものがあればエラーメッセージを返す。問題なければNone。
+
+    エラーメッセージにはユーザー入力の作者名がそのまま含まれるため、呼び出し側で
+    HTMLエスケープしてから画面に表示すること（views/song_edit.pyのcontext["error"]は
+    song_edit.html側で|safeによりオートエスケープが無効化されているため必須）。
+    """
     max_length = Author._meta.get_field('name').max_length
     for name in _non_empty_names(author_names):
         if len(name) > max_length:
-            return f"作者名は{max_length}文字以下である必要があります：{name}"
+            # トースト表示が崩れないよう、メッセージに含める名前自体は短く切り詰める
+            displayed_name = name if len(name) <= 50 else name[:50] + "…"
+            return f"作者名は{max_length}文字以下である必要があります：{displayed_name}"
     return None
 
 

--- a/subekashi/lib/song_service.py
+++ b/subekashi/lib/song_service.py
@@ -22,7 +22,11 @@ def yes_no(value):
 
 
 def validate_song_url(cleaned_url, exclude_song_id=None):
-    """URLの重複チェック。エラーメッセージを返す。問題なければNone。"""
+    """URLの長さ・重複チェック。エラーメッセージを返す。問題なければNone。"""
+    max_length = SongLink._meta.get_field('url').max_length
+    if len(cleaned_url) > max_length:
+        return f"URLは{max_length}文字以下である必要があります。"
+
     qs = SongLink.objects.filter(url__iexact=cleaned_url, allow_dup=False, songs__isnull=False)
     if exclude_song_id is not None:
         qs = qs.exclude(songs__id=exclude_song_id)

--- a/subekashi/models/history.py
+++ b/subekashi/models/history.py
@@ -27,7 +27,7 @@ class History(models.Model):
     def create_for_song(cls, song, title, history_type, changes, editor):
         history = cls(
             song=song,
-            title=title,
+            title=title[:cls._meta.get_field("title").max_length],
             history_type=history_type,
             create_time=timezone.now(),
             changes=changes,
@@ -40,7 +40,7 @@ class History(models.Model):
     def create_for_author(cls, author, title, history_type, changes, editor):
         history = cls(
             author=author,
-            title=title,
+            title=title[:cls._meta.get_field("title").max_length],
             history_type=history_type,
             create_time=timezone.now(),
             changes=changes,

--- a/subekashi/templates/subekashi/contact.html
+++ b/subekashi/templates/subekashi/contact.html
@@ -19,7 +19,7 @@
         </div>
         <div class="form-col">
             <label for="detail">詳細<sup>*</sup></label>
-            <textarea id="detail" name="detail" required>{{ request.GET.detail }}</textarea>
+            <textarea id="detail" name="detail" maxlength="10000" required>{{ request.GET.detail }}</textarea>
         </div>
         <input type="submit" id="content-submit" name="content-submit" value="送信">
         <p id="contact-info"></p>

--- a/subekashi/templates/subekashi/song_edit.html
+++ b/subekashi/templates/subekashi/song_edit.html
@@ -24,7 +24,7 @@
         {% comment %} TODO 別名の入力項目を追加 {% endcomment %}
         <div class="form-col">
             <label for="title">曲名<i class="fas fa-info-circle" onclick="showTutorial('title')"></i></label>
-            <input type="text" id="title" name="title" class="sansfont" value="{{ song.title }}" required>
+            <input type="text" id="title" name="title" class="sansfont" value="{{ song.title }}" maxlength="500" required>
         </div>
         <div class="form-col">
             <label for="authors">作者<br>(複数可)<i class="fas fa-info-circle" onclick="showTutorial('authors')"></i></label>
@@ -64,7 +64,7 @@
         </div>
         <div class="form-col" data-hide-if-questionable>
             <label for="lyrics">歌詞<i class="fas fa-info-circle" onclick="showTutorial('lyrics')"></i></label>
-            <textarea id="lyrics" name="lyrics">{{ song.lyrics }}</textarea>
+            <textarea id="lyrics" name="lyrics" maxlength="10000">{{ song.lyrics }}</textarea>
         </div>
         <div class="checkbox-col" data-hide-if-questionable>
             <input type="checkbox" id="is-original" name="is_original" {% if song.is_original %}checked{% endif %}>

--- a/subekashi/templates/subekashi/song_new.html
+++ b/subekashi/templates/subekashi/song_new.html
@@ -51,7 +51,7 @@
     <form action="{% url 'subekashi:song_new' %}?toast=manual" method="POST" id="new-form-manual">{% csrf_token %}
         <div class="form-col">
             <label for="title">曲名<i class="fas fa-info-circle" onclick="showTutorial('title')"></i></label>
-            <input type="text" id="title" name="title" class="sansfont" value="{{ request.GET.title }}" required>
+            <input type="text" id="title" name="title" class="sansfont" value="{{ request.GET.title }}" maxlength="500" required>
         </div>
         <div class="form-col">
             <label for="authors">作者<br>(複数可)<i class="fas fa-info-circle" onclick="showTutorial('authors')"></i></label>

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -112,6 +112,8 @@
 | 自分自身を除外した場合 | `exclude_song_id` を指定し、同じ曲のURL | `None` を返す |
 | `allow_dup=True` のSongLink | 重複URLだが `allow_dup=True` | `None` を返す |
 | 曲に紐付いていないSongLink | リンクは存在するが曲なし | `None` を返す |
+| URLが`SongLink.url`のmax_length丁度 (#1085) | `len(url) == max_length` | `None` を返す |
+| URLが`SongLink.url`のmax_length超過 (#1085) | `len(url) == max_length + 1` | エラーメッセージ文字列を返す（MySQL移行時のData too long for column対策） |
 
 #### 2-3. `create_song(fields)`
 
@@ -336,6 +338,15 @@
 | past正規化とREJECT_LISTすり抜け防止 (#1008) | REJECT_LIST登録済みauthorのpast別名で入力 | `get_or_create_authors()`が現在の名義に正規化するため、`check_reject_list()`が正しく検知できる |
 | past別名の一括取得 (#1008) | past別名5件を含む入力 | past別名の存在チェックが名前ごとに都度クエリを発行せず、1クエリで一括取得される（N+1にならない） |
 
+#### 5-1. `validate_author_name_lengths(author_names)`（#1085）
+
+| テストケース | 入力 | 期待結果 |
+| --- | --- | --- |
+| 上限内の名前のみ | `["作者A", "作者B"]` | `None` を返す |
+| `Author.name`のmax_length丁度 | `len(name) == max_length` | `None` を返す |
+| `Author.name`のmax_length超過 | `len(name) == max_length + 1` | エラーメッセージ文字列を返す（MySQL移行時のData too long for column対策） |
+| 空文字列はスキップ | `["", "作者A", ""]` | `None` を返す |
+
 ---
 
 ### 6. `forms.py` — フォームバリデーション
@@ -350,6 +361,8 @@
 | categoryが空 | `category=""`, `detail="内容"` | `is_valid() == False`、エラーメッセージあり |
 | detailが空 | `category="質問"`, `detail=""` | `is_valid() == False`、エラーメッセージあり |
 | 不正なcategory値 | `category="不正な選択肢"` | `is_valid() == False` |
+| detailが10000文字丁度 (#1085) | `detail="あ" * 10000` | `is_valid() == True` |
+| detailが10000文字超 (#1085) | `detail="あ" * 10001` | `is_valid() == False` |
 
 #### 6-2. `SongDeleteForm`
 
@@ -369,6 +382,8 @@
 | is_original など boolean フラグ | `is_original=True` | `cleaned_data["is_original"] == True` |
 | is_questionable boolean フラグ | `is_questionable=True` | `cleaned_data["is_questionable"] == True` |
 | titleが500文字超 | `title="あ" * 501` | `is_valid() == False` |
+| lyricsが10000文字丁度 (#1085) | `lyrics="あ" * 10000` | `is_valid() == True` |
+| lyricsが10000文字超 (#1085) | `lyrics="あ" * 10001` | `is_valid() == False` |
 
 #### 6-4. `AuthorAliasForm`（#992）
 
@@ -464,6 +479,8 @@ DBアクセス（候補・衝突チェック）を伴うため `TestCase` を使
 | POST: YouTube以外のURL | `url="https://example.com/..."` | HTTP 200、"YouTube" を含むエラー |
 | POST: 作者が空白 | `url=""`, `authors="  "` | HTTP 200、"作者" を含むエラー |
 | POST: タイトルが空 | `url=""`, `authors="テスト作者"`, `title=""` | HTTP 200、"タイトル" を含むエラー |
+| POST: タイトルが`Song.title`のmax_length超（#1085） | `title`がmax_length+1文字 | HTTP 200、"タイトル" を含むエラー、Songは作成されない（フォームを経由せず保存するため直接バリデーションが必要） |
+| POST: 作者名が`Author.name`のmax_length超（#1085） | `authors`がmax_length+1文字 | HTTP 200、"作者名" を含むエラー、Songは作成されない |
 | POST: is-questionable時、オリジナル模倣は強制OFF・その他フラグの入力値はそのまま保存される | `is-questionable-manual=on`, `is-original-manual=on`, `is-subeana-manual=on` | 保存されたSongの `is_questionable=True`、`is_original=False`、`is_subeana=True` |
 | POST: 作者名がpast別名と一致し一番有名な名義へ正規化される（#1029） | `authors=`past別名のname | 保存後、redirect先URLに`primary_name_normalized=1`が付与される |
 | POST: 正規化が発生しない | `authors=`通常の作者名 | redirect先URLに`primary_name_normalized`は付与されない |
@@ -476,6 +493,7 @@ DBアクセス（候補・衝突チェック）を伴うため `TestCase` を使
 | 存在しない曲のGET | 無効なsong_id | HTTP 404 |
 | POST: is_questionable時に歌詞・模倣・下書き・オリジナル模倣が強制的に空/OFF | `is_questionable=True`, `lyrics="..."`, `imitate="<id>"`, `is_draft=True`, `is_original=True` | 保存されたSongの `lyrics=""`、`imitates`が空、`is_draft=False`、`is_original=False`、`is_questionable=True` |
 | POST: is_questionable時も非公開/削除済み・ネタ曲・インスト・すべあな界隈曲は保存される | `is_questionable=True`, `is_deleted=True`, `is_joke=True`, `is_inst=True`, `is_subeana=True` | 各フラグがそれぞれ `True` のまま保存される |
+| POST: 作者名が`Author.name`のmax_length超（#1085） | `authors`がmax_length+1文字 | HTTP 200、"作者名" を含むエラー |
 | POST: 作者名がpast別名と一致し一番有名な名義へ正規化される（#1029） | `authors=`past別名のname | 保存後、redirect先URLに`primary_name_normalized=1`が付与される |
 | POST: 正規化が発生しない | `authors=`通常の作者名 | redirect先URLに`primary_name_normalized`は付与されない |
 
@@ -976,6 +994,8 @@ DBアクセス（候補・衝突チェック）を伴うため `TestCase` を使
 | `create_for_song()` | `History.create_for_song(song=song, ...)` | `history.song`が設定され`history.author`は`None`のまま |
 | authorの削除 | `create_for_author()`後に`author.delete()` | `history.author`が`None`になる（`on_delete=SET_NULL`、Historyレコード自体は残る） |
 | `get_for_author(author)` | 複数authorのHistoryが存在する状態で対象authorを指定 | 対象authorのHistoryのみが`-create_time`順で返される |
+| `create_for_song()`のtitle切り詰め (#1085) | `title`が200文字（`History.title`のmax_length=100超） | 保存されたtitleが100文字に切り詰められる（MySQL移行時のData too long for column対策。Song.titleを含む動的titleがHistory.titleの上限を超えうるため） |
+| `create_for_author()`のtitle切り詰め (#1085) | `title`が200文字 | 保存されたtitleが100文字に切り詰められる |
 
 #### 11-7. `Word` モデル（#1053）
 

--- a/subekashi/tests/test_forms.py
+++ b/subekashi/tests/test_forms.py
@@ -50,6 +50,15 @@ class ContactFormTest(SimpleTestCase):
         form.is_valid()
         self.assertIn("入力必須項目を入力してください。", form.errors["category"])
 
+    def test_detail_max_length_10000_is_valid(self):
+        form = ContactForm(data=self._make_data(detail="あ" * 10000))
+        self.assertTrue(form.is_valid())
+
+    def test_detail_over_10000_chars_is_invalid(self):
+        form = ContactForm(data=self._make_data(detail="あ" * 10001))
+        self.assertFalse(form.is_valid())
+        self.assertIn("detail", form.errors)
+
 
 class SongDeleteFormTest(SimpleTestCase):
     """SongDeleteForm のテスト"""
@@ -128,6 +137,15 @@ class SongEditFormTest(SimpleTestCase):
         form = SongEditForm(data=self._make_data(title="あ" * 501))
         self.assertFalse(form.is_valid())
         self.assertIn("title", form.errors)
+
+    def test_lyrics_max_length_10000_is_valid(self):
+        form = SongEditForm(data=self._make_data(lyrics="あ" * 10000))
+        self.assertTrue(form.is_valid())
+
+    def test_lyrics_over_10000_chars_is_invalid(self):
+        form = SongEditForm(data=self._make_data(lyrics="あ" * 10001))
+        self.assertFalse(form.is_valid())
+        self.assertIn("lyrics", form.errors)
 
     def test_boolean_flag_is_original_true(self):
         form = SongEditForm(data=self._make_data(is_original=True))

--- a/subekashi/tests/test_lib_author_helpers.py
+++ b/subekashi/tests/test_lib_author_helpers.py
@@ -8,7 +8,7 @@ test_author_migration.py の AuthorHelpersTest と重複する部分があるが
 from unittest.mock import MagicMock, patch
 from django.test import TestCase
 from subekashi.models import Author, AuthorAlias
-from subekashi.lib.author_helpers import get_or_create_authors
+from subekashi.lib.author_helpers import get_or_create_authors, validate_author_name_lengths
 from subekashi.lib.song_service import check_reject_list
 
 
@@ -123,3 +123,24 @@ class GetOrCreateAuthorsTest(TestCase):
             authors = get_or_create_authors([f"以前の名義{i}" for i in range(5)])
 
         self.assertEqual(len(authors), 5)
+
+
+class ValidateAuthorNameLengthsTest(TestCase):
+    """validate_author_name_lengths() のテスト（#1085）"""
+
+    def test_names_within_limit_return_none(self):
+        self.assertIsNone(validate_author_name_lengths(["作者A", "作者B"]))
+
+    def test_name_at_max_length_is_valid(self):
+        max_length = Author._meta.get_field("name").max_length
+        self.assertIsNone(validate_author_name_lengths(["あ" * max_length]))
+
+    def test_name_over_max_length_returns_error_message(self):
+        max_length = Author._meta.get_field("name").max_length
+        too_long_name = "あ" * (max_length + 1)
+        error = validate_author_name_lengths(["作者A", too_long_name])
+        self.assertIsNotNone(error)
+        self.assertIn(str(max_length), error)
+
+    def test_empty_strings_are_skipped(self):
+        self.assertIsNone(validate_author_name_lengths(["", "作者A", ""]))

--- a/subekashi/tests/test_lib_song_service.py
+++ b/subekashi/tests/test_lib_song_service.py
@@ -99,6 +99,21 @@ class ValidateSongUrlTest(TestCase):
         result = validate_song_url("https://youtu.be/nosongslink1")
         self.assertIsNone(result)
 
+    def test_url_at_max_length_returns_none(self):
+        # #1085: MySQL移行時のData too long for column対策
+        max_length = SongLink._meta.get_field("url").max_length
+        url = "https://youtu.be/" + "a" * (max_length - len("https://youtu.be/"))
+        self.assertEqual(len(url), max_length)
+        result = validate_song_url(url)
+        self.assertIsNone(result)
+
+    def test_url_over_max_length_returns_error_message(self):
+        max_length = SongLink._meta.get_field("url").max_length
+        url = "https://youtu.be/" + "a" * (max_length - len("https://youtu.be/") + 1)
+        result = validate_song_url(url)
+        self.assertIsNotNone(result)
+        self.assertIn(str(max_length), result)
+
 
 class CreateSongTest(TestCase):
     """create_song() のテスト"""

--- a/subekashi/tests/test_models.py
+++ b/subekashi/tests/test_models.py
@@ -546,6 +546,33 @@ class HistoryModelTest(TestCase):
         self.assertEqual(history.song, self.song)
         self.assertIsNone(history.author)
 
+    def test_create_for_song_truncates_long_title(self):
+        # Song.title（max_length=500）を含む動的titleがHistory.title（max_length=100）を
+        # 超えることがあるため、MySQL移行時にData too long for columnエラーにならないよう
+        # 保存前に切り詰める（#1085）
+        long_title = "あ" * 200
+        history = History.create_for_song(
+            song=self.song,
+            title=long_title,
+            history_type="new",
+            changes=None,
+            editor=self.editor,
+        )
+        self.assertEqual(len(history.title), 100)
+        self.assertEqual(history.title, "あ" * 100)
+
+    def test_create_for_author_truncates_long_title(self):
+        long_title = "い" * 200
+        history = History.create_for_author(
+            author=self.author,
+            title=long_title,
+            history_type="edit",
+            changes=None,
+            editor=self.editor,
+        )
+        self.assertEqual(len(history.title), 100)
+        self.assertEqual(history.title, "い" * 100)
+
     def test_author_set_null_on_author_delete(self):
         history = History.create_for_author(
             author=self.author,

--- a/subekashi/tests/test_views.py
+++ b/subekashi/tests/test_views.py
@@ -377,6 +377,52 @@ class SongEditViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("作者名", response.context["error"])
 
+    def test_post_author_name_error_escapes_html_in_response(self):
+        # コードレビュー指摘対応（反射型XSS）: song_edit.html側は{{ error|safe }}で
+        # オートエスケープが無効化されているため、エラーメッセージに含まれる作者名は
+        # view側で明示的にエスケープされていないと、HTMLタグを注入できてしまう
+        max_length = Author._meta.get_field("name").max_length
+        malicious_name = "<script>alert(1)</script>" * (max_length // 20 + 1)
+        response = self.client.post(
+            reverse("subekashi:song_edit", args=[self.song.id]),
+            {"title": "編集テスト曲", "authors": malicious_name, "url": ""},
+        )
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertNotIn("<script>alert(1)</script>", content)
+        self.assertIn("&lt;script&gt;", content)
+
+    def test_post_untrusted_url_error_escapes_html_in_response(self):
+        # コードレビュー指摘対応（反射型XSS）: 「信頼されていないURL」エラーは
+        # cleaned_url_itemをそのままHTMLとして埋め込んでいたため、URLにHTMLタグを
+        # 含めるとscriptタグを注入できてしまっていた
+        malicious_url = "https://example.com/<script>alert(1)</script>"
+        response = self.client.post(
+            reverse("subekashi:song_edit", args=[self.song.id]),
+            {"title": "編集テスト曲", "authors": "テスト作者", "url": malicious_url},
+        )
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertNotIn("<script>alert(1)</script>", content)
+        self.assertIn("&lt;script&gt;", content)
+
+    def test_post_reject_list_error_escapes_html_in_response(self):
+        # コードレビュー指摘対応（反射型XSS）: check_reject_list()が返すエラーメッセージには
+        # author.nameがそのまま含まれるため、HTMLタグを含む名前がREJECT_LISTに一致した
+        # 場合にview側でエスケープしていないとXSSになりうる
+        malicious_name = "<script>alert(1)</script>"
+        mock_reject_module = MagicMock()
+        mock_reject_module.REJECT_LIST = [malicious_name]
+        with patch.dict("sys.modules", {"subekashi.constants.dynamic.reject": mock_reject_module}):
+            response = self.client.post(
+                reverse("subekashi:song_edit", args=[self.song.id]),
+                {"title": "編集テスト曲", "authors": malicious_name, "url": ""},
+            )
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertNotIn("<script>alert(1)</script>", content)
+        self.assertIn("&lt;script&gt;", content)
+
     def test_post_questionable_forces_lyrics_and_imitate_blank(self):
         # is_questionable時、歌詞・模倣・下書きはユーザー入力に関わらず空/OFFになる
         imitate_target = Song.objects.create(title="模倣元テスト曲")

--- a/subekashi/tests/test_views.py
+++ b/subekashi/tests/test_views.py
@@ -284,6 +284,29 @@ class SongNewViewTest(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn("タイトル", response.context["error"])
 
+    def test_post_title_over_max_length_returns_error(self):
+        # #1085: SongNewViewはフォームを経由せずtitleを保存するため、
+        # 直接バリデーションが必要（MySQL移行時のData too long for column対策）
+        max_length = Song._meta.get_field("title").max_length
+        response = self.client.post(
+            reverse("subekashi:song_new"),
+            {"url": "", "authors": "テスト作者", "title": "あ" * (max_length + 1)},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("タイトル", response.context["error"])
+        self.assertFalse(Song.objects.filter(title__startswith="あ" * 10).exists())
+
+    def test_post_author_name_over_max_length_returns_error(self):
+        # #1085: MySQL移行時のData too long for column対策
+        max_length = Author._meta.get_field("name").max_length
+        response = self.client.post(
+            reverse("subekashi:song_new"),
+            {"url": "", "authors": "い" * (max_length + 1), "title": "長い作者名テスト曲"},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("作者名", response.context["error"])
+        self.assertFalse(Song.objects.filter(title="長い作者名テスト曲").exists())
+
     def test_post_questionable_forces_original_false(self):
         # is-questionable時、オリジナル模倣はユーザーの入力値に関わらず強制的にFalseになる
         response = self.client.post(
@@ -343,6 +366,16 @@ class SongEditViewTest(TestCase):
     def test_nonexistent_song_returns_404(self):
         response = self.client.get(reverse("subekashi:song_edit", args=[99999]))
         self.assertEqual(response.status_code, 404)
+
+    def test_post_author_name_over_max_length_returns_error(self):
+        # #1085: MySQL移行時のData too long for column対策
+        max_length = Author._meta.get_field("name").max_length
+        response = self.client.post(
+            reverse("subekashi:song_edit", args=[self.song.id]),
+            {"title": "編集テスト曲", "authors": "う" * (max_length + 1), "url": ""},
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("作者名", response.context["error"])
 
     def test_post_questionable_forces_lyrics_and_imitate_blank(self):
         # is_questionable時、歌詞・模倣・下書きはユーザー入力に関わらず空/OFFになる

--- a/subekashi/tests/test_views.py
+++ b/subekashi/tests/test_views.py
@@ -307,6 +307,22 @@ class SongNewViewTest(TestCase):
         self.assertIn("作者名", response.context["error"])
         self.assertFalse(Song.objects.filter(title="長い作者名テスト曲").exists())
 
+    def test_post_author_name_error_escapes_html_in_response(self):
+        # song_new.html側は{{ error }}で（|safeを使わず）Djangoの標準オートエスケープに
+        # 任せる設計のため、song_edit.py側のような明示的なescape()呼び出しは不要だが、
+        # 将来テンプレートが|safeに変更された場合に気付けるよう回帰防止テストを置いておく
+        max_length = Author._meta.get_field("name").max_length
+        malicious_name = "<script>alert(1)</script>" * (max_length // 20 + 1)
+        response = self.client.post(
+            reverse("subekashi:song_new"),
+            {"url": "", "authors": malicious_name, "title": "XSSテスト曲"},
+        )
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertNotIn("<script>alert(1)</script>", content)
+        self.assertIn("&lt;script&gt;", content)
+        self.assertFalse(Song.objects.filter(title="XSSテスト曲").exists())
+
     def test_post_questionable_forces_original_false(self):
         # is-questionable時、オリジナル模倣はユーザーの入力値に関わらず強制的にFalseになる
         response = self.client.post(
@@ -405,6 +421,21 @@ class SongEditViewTest(TestCase):
         content = response.content.decode()
         self.assertNotIn("<script>alert(1)</script>", content)
         self.assertIn("&lt;script&gt;", content)
+
+    def test_post_untrusted_url_error_url_encodes_query_param(self):
+        # コードレビュー指摘対応: お問い合わせリンクのdetail=クエリパラメータは
+        # HTMLエスケープのみではURLに含まれる&や#でクエリ文字列が途中で切れてしまうため、
+        # URLエンコードされていることを確認する
+        url_with_special_chars = "https://example.com/video?a=1&b=2"
+        response = self.client.post(
+            reverse("subekashi:song_edit", args=[self.song.id]),
+            {"title": "編集テスト曲", "authors": "テスト作者", "url": url_with_special_chars},
+        )
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        # &がエンコードされずそのまま出力されていると、クエリ文字列が途中で切れてしまう
+        self.assertNotIn("detail=https://example.com/video?a=1&b=2", content)
+        self.assertIn("a%3D1%26b%3D2", content)
 
     def test_post_reject_list_error_escapes_html_in_response(self):
         # コードレビュー指摘対応（反射型XSS）: check_reject_list()が返すエラーメッセージには

--- a/subekashi/views/song_edit.py
+++ b/subekashi/views/song_edit.py
@@ -8,7 +8,7 @@ from subekashi.models import Song, Editor, History, SongLink, SongFields
 from subekashi.lib.url import clean_url, get_allow_media
 from subekashi.lib.ip import get_ip
 from subekashi.lib.discord import send_discord
-from subekashi.lib.author_helpers import get_or_create_authors, author_names_were_normalized
+from subekashi.lib.author_helpers import get_or_create_authors, author_names_were_normalized, validate_author_name_lengths
 from subekashi.lib.song_service import (
     check_reject_list,
     validate_song_url,
@@ -101,6 +101,13 @@ class SongEditView(View):
 
         # authorsフィールドの処理: カンマ区切りの作者をAuthorオブジェクトに変換
         author_names = cleaned_authors.split(',')
+
+        # 作者名が長すぎる場合はエラー
+        author_name_error = validate_author_name_lengths(author_names)
+        if author_name_error:
+            context["error"] = author_name_error
+            return render(request, 'subekashi/song_edit.html', context)
+
         author_objects = get_or_create_authors(author_names)
         # 入力した作者名が一番有名な名義（past別名から変換）に正規化されたかどうか
         primary_name_normalized = author_names_were_normalized(author_names, author_objects)

--- a/subekashi/views/song_edit.py
+++ b/subekashi/views/song_edit.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render, redirect
 from django.urls import reverse
+from django.utils.html import escape
 from django.views import View
 from config.settings import ROOT_URL
 from config.local_settings import NEW_DISCORD_URL, CONTACT_DISCORD_URL
@@ -90,8 +91,11 @@ class SongEditView(View):
             # 許可されていないメディアのURLならばエラー
             if not get_allow_media(cleaned_url_item):
                 contact_url = reverse('subekashi:contact')
-                context["error"] = f"URL：{cleaned_url_item}は信頼されていないURLと判断されました。<br>\
-                <a href='{contact_url}?&category=提案&detail={cleaned_url_item} を登録できるようにしてください。' target='_blank'>お問い合わせ</a>にて、\
+                # song_edit.html側は{{ error|safe }}でオートエスケープを無効化しているため、
+                # ユーザー入力（cleaned_url_item）はここで明示的にエスケープする（XSS対策）
+                escaped_url = escape(cleaned_url_item)
+                context["error"] = f"URL：{escaped_url}は信頼されていないURLと判断されました。<br>\
+                <a href='{contact_url}?&category=提案&detail={escaped_url} を登録できるようにしてください。' target='_blank'>お問い合わせ</a>にて、\
                 該当のURLを登録できるように、ご連絡ください。"
                 return render(request, 'subekashi/song_edit.html', context)
 
@@ -102,10 +106,10 @@ class SongEditView(View):
         # authorsフィールドの処理: カンマ区切りの作者をAuthorオブジェクトに変換
         author_names = cleaned_authors.split(',')
 
-        # 作者名が長すぎる場合はエラー
+        # 作者名が長すぎる場合はエラー（song_edit.html側の|safeのためエスケープが必要）
         author_name_error = validate_author_name_lengths(author_names)
         if author_name_error:
-            context["error"] = author_name_error
+            context["error"] = escape(author_name_error)
             return render(request, 'subekashi/song_edit.html', context)
 
         author_objects = get_or_create_authors(author_names)
@@ -115,10 +119,10 @@ class SongEditView(View):
         # 自分自身や重複は除外し、Song オブジェクトのリストに変換
         imitate_songs = get_imitate_songs(imitates, song_id)
 
-        # 掲載拒否作者か判断する
+        # 掲載拒否作者か判断する（author.nameを含むためエスケープが必要）
         reject_error = check_reject_list(author_objects)
         if reject_error:
-            context["error"] = reject_error
+            context["error"] = escape(reject_error)
             return render(request, 'subekashi/song_edit.html', context)
 
         fields = SongFields(

--- a/subekashi/views/song_edit.py
+++ b/subekashi/views/song_edit.py
@@ -1,3 +1,4 @@
+from urllib.parse import quote
 from django.shortcuts import render, redirect
 from django.urls import reverse
 from django.utils.html import escape
@@ -94,8 +95,11 @@ class SongEditView(View):
                 # song_edit.html側は{{ error|safe }}でオートエスケープを無効化しているため、
                 # ユーザー入力（cleaned_url_item）はここで明示的にエスケープする（XSS対策）
                 escaped_url = escape(cleaned_url_item)
+                # クエリパラメータdetail=にはURLエンコードした値を埋め込む（HTMLエスケープのみでは
+                # &や#を含むURLでクエリ文字列が途中で切れてしまうため）
+                detail_query = quote(f"{cleaned_url_item} を登録できるようにしてください。")
                 context["error"] = f"URL：{escaped_url}は信頼されていないURLと判断されました。<br>\
-                <a href='{contact_url}?&category=提案&detail={escaped_url} を登録できるようにしてください。' target='_blank'>お問い合わせ</a>にて、\
+                <a href='{contact_url}?&category=提案&detail={detail_query}' target='_blank'>お問い合わせ</a>にて、\
                 該当のURLを登録できるように、ご連絡ください。"
                 return render(request, 'subekashi/song_edit.html', context)
 

--- a/subekashi/views/song_new.py
+++ b/subekashi/views/song_new.py
@@ -3,12 +3,12 @@ from django.db import transaction
 from django.views import View
 from config.settings import ROOT_URL
 from config.local_settings import CONTACT_DISCORD_URL, NEW_DISCORD_URL
-from subekashi.models import Editor, History, SongLink, SongFields
+from subekashi.models import Editor, History, Song, SongLink, SongFields
 from subekashi.lib.url import clean_url, is_youtube_url, get_youtube_id
 from subekashi.lib.ip import get_ip
 from subekashi.lib.discord import send_discord
 from subekashi.lib.youtube import get_youtube_api
-from subekashi.lib.author_helpers import get_or_create_authors, author_names_were_normalized
+from subekashi.lib.author_helpers import get_or_create_authors, author_names_were_normalized, validate_author_name_lengths
 from subekashi.lib.song_service import (
     check_reject_list,
     validate_song_url,
@@ -89,10 +89,23 @@ class SongNewView(View):
             context["error"] = "タイトルが未入力です。"
             return render(request, 'subekashi/song_new.html', context)
 
+        # タイトルが長すぎる場合はエラー
+        title_max_length = Song._meta.get_field('title').max_length
+        if len(title) > title_max_length:
+            context["error"] = f"タイトルは{title_max_length}文字以下である必要があります。"
+            return render(request, 'subekashi/song_new.html', context)
+
         cleaned_authors = authors_input.replace(" ,", ",").replace(", ", ",")
 
         # authorsフィールドの処理: カンマ区切りの作者名をAuthorオブジェクトに変換
         author_names = cleaned_authors.split(',')
+
+        # 作者名が長すぎる場合はエラー
+        author_name_error = validate_author_name_lengths(author_names)
+        if author_name_error:
+            context["error"] = author_name_error
+            return render(request, 'subekashi/song_new.html', context)
+
         authors = get_or_create_authors(author_names)
         # 入力した作者名が一番有名な名義（past別名から変換）に正規化されたかどうか
         primary_name_normalized = author_names_were_normalized(author_names, authors)


### PR DESCRIPTION
## Summary

#1085で洗い出した、DBのCharField/TextFieldに対応するアプリ層の文字列長バリデーション欠落を修正しました。SQLiteはmax_lengthをDBレベルで強制しないため実害がありませんでしたが、MySQLのstrict mode下では「Data too long for column」エラーになりうる箇所でした。

- `History.title`（max_length=100）: `Song.title`・`Author.name`を含む動的titleが上限を超えうるため、`History.create_for_song`/`create_for_author`の保存前に100文字へ切り詰め
- `validate_song_url()`にURL長チェックを追加（`song_new.py`/`song_edit.py`双方に自動適用）
- `author_helpers.py`に`validate_author_name_lengths()`を追加し、`song_new.py`/`song_edit.py`で作者名の長さを検証
- `SongNewView.post`にtitleの長さチェックを追加（フォームを経由せず直接保存するため、これまで未検証だった）
- `SongEditForm.lyrics`・`ContactForm.detail`にmax_length=10000を追加
- 対応するテンプレートにフロントエンドのmaxlength属性を追加

## セキュリティ修正（コードレビュー対応、反射型XSS）

本PRで`validate_author_name_lengths()`を追加した際、そのエラーメッセージがユーザー入力の作者名をそのまま含んでいることが判明しました。`song_edit.html`側のエラー表示は`showToast("error", "{{ error|safe }}")`でDjangoのオートエスケープを無効化しており、他の既存のエラーメッセージ（「信頼されていないURL」エラーの`cleaned_url_item`、掲載拒否エラーの`author.name`）も同様に未エスケープでユーザー入力を埋め込んでいたため、細工した文字列を送信することでJS文字列リテラルを閉じて任意スクリプトを注入できる状態でした（`song_new.html`側は`|safe`を使っておらずDjangoの標準オートエスケープが効くため対象外）。

- `views/song_edit.py`の3箇所（URL・作者名・掲載拒否のエラーメッセージ）に`django.utils.html.escape()`を追加（`views/song_edit.py:96,112,125`付近）
- `validate_author_name_lengths()`のエラーメッセージに含める作者名を、トースト表示が崩れないよう50文字に切り詰め
- 併せて、「信頼されていないURL」エラーのお問い合わせリンクで、`detail=`クエリパラメータがHTMLエスケープのみでURLエンコードされていなかった既存の問題（URLに`&`や`#`を含むとクエリ文字列が途中で切れる）も、この行に手を入れたついでに`urllib.parse.quote()`で修正
- `song_new.py`側（対象外と判断した経路）にも、将来テンプレートが`|safe`に変更された場合に気付けるよう回帰防止テストを追加
- `SongEditForm.url`/`authors`にmax_lengthを付与していない理由（カンマ区切りで複数値を受け付けるため）をコメントで明記

## Test plan

- [x] 新規バリデーション・XSS修正に対するテストを追加（`test_models.py`/`test_forms.py`/`test_lib_author_helpers.py`/`test_lib_song_service.py`/`test_views.py`）
- [x] SQLiteで`python manage.py test subekashi.tests article.tests`全900件PASS
- [x] ローカルMySQL 8.4で同テスト全900件PASS
- [x] 実際にDjango開発サーバーを起動し、テンプレートのmaxlength属性が正しくレンダリングされることを確認
- [x] `TEST_PLAN_UNIT.md`を更新

closes #1085

🤖 Generated with [Claude Code](https://claude.com/claude-code)