### PR TITLE
MySQL接続でStrict Modeを明示的に有効化（#1091）

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -99,10 +99,16 @@ DATABASES = {
         # 含まない設定になっており、max_length超過等の不正な値を挿入しようとしても
         # エラーにならず警告のみで黙って切り詰められてしまう（#593の移行作業で発覚、#1091）。
         # サーバー側の設定に依存せず常にstrictな検証が働くよう、接続時に明示的に設定する。
-        # 既存のsql_mode（環境によって異なりうる）を上書きしないよう追加する形にする
+        # 既存のsql_mode（環境によって異なりうる）を上書きしないよう追加する形にする。
+        # init_commandは全接続確立時に毎回実行されるため、万一@@sql_modeが空文字列の
+        # 環境があった場合に先頭カンマ付きの値になってエラーにならないよう、
+        # IF()で空文字列ガードを入れておく（コードレビュー対応）
         "OPTIONS": {
             "charset": "utf8mb4",
-            "init_command": "SET sql_mode=CONCAT(@@sql_mode, ',STRICT_TRANS_TABLES')",
+            "init_command": (
+                "SET sql_mode=CONCAT("
+                "IF(@@sql_mode = '', '', CONCAT(@@sql_mode, ',')), 'STRICT_TRANS_TABLES')"
+            ),
         },
         # MySQLサーバーの既定照合順序に依存すると環境ごとに挙動が変わってしまうため
         # （#1092、本番はutf8mb4_binで運用しているが、サーバー設定次第では

--- a/config/settings.py
+++ b/config/settings.py
@@ -95,7 +95,15 @@ DATABASES = {
         "PASSWORD": MYSQL_PASSWORD,
         "HOST": MYSQL_HOST,
         **({"PORT": MYSQL_PORT} if MYSQL_PORT else {}),
-        "OPTIONS": {"charset": "utf8mb4"},
+        # PythonAnywhereの共有MySQLサーバーはsql_modeにSTRICT_TRANS_TABLESを
+        # 含まない設定になっており、max_length超過等の不正な値を挿入しようとしても
+        # エラーにならず警告のみで黙って切り詰められてしまう（#593の移行作業で発覚、#1091）。
+        # サーバー側の設定に依存せず常にstrictな検証が働くよう、接続時に明示的に設定する。
+        # 既存のsql_mode（環境によって異なりうる）を上書きしないよう追加する形にする
+        "OPTIONS": {
+            "charset": "utf8mb4",
+            "init_command": "SET sql_mode=CONCAT(@@sql_mode, ',STRICT_TRANS_TABLES')",
+        },
         # MySQLサーバーの既定照合順序に依存すると環境ごとに挙動が変わってしまうため
         # （#1092、本番はutf8mb4_binで運用しているが、サーバー設定次第では
         # 大文字小文字を区別しないutf8mb4_general_ci等でテストDBが作られうる）、

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -927,6 +927,7 @@ DBアクセス（候補・衝突チェック）を伴うため `TestCase` を使
 | --- | --- | --- |
 | 作者の作成 | `Author.objects.create(name="テスト作者")` | DBに保存される |
 | `name` のユニーク制約 | 同じ名前で2件作成 | `IntegrityError` が発生 |
+| Strict Modeによるmax_length超過の拒否 (#1091、MySQLのみ) | `max_length=255`を超える`name`で`save()` | `DataError`が発生（`config/settings.py`のinit_commandでSTRICT_TRANS_TABLESを有効化しているため） |
 | `name` の大文字小文字違いは別レコード (#1092) | `"MoAI"`と`"moai"`をそれぞれ作成 | 両方ともDBに保存される（一意制約はバイト完全一致で判定） |
 | `name=`によるexact matchは大文字小文字を区別する (#1092) | 上記の状態で`filter(name="MoAI")` | `"MoAI"`のみヒットする（`"moai"`はヒットしない） |
 | `get_by_name()`は大文字小文字違いが共存してもエラーにならない (#1092) | 上記の状態で`get_by_name("MoAI")`と`get_by_name("moai")` | それぞれ対応するレコードを返す（`MultipleObjectsReturned`は発生しない） |

--- a/subekashi/tests/test_models.py
+++ b/subekashi/tests/test_models.py
@@ -3,7 +3,9 @@
 
 Song, Author, AuthorAlias, SongLink の CRUD・制約・メソッドを検証する。
 """
-from django.db import IntegrityError
+import unittest
+from django.db import IntegrityError, connection
+from django.db.utils import DataError
 from django.test import TestCase
 from django.utils import timezone
 from subekashi.models import Ai, Author, AuthorAlias, Contact, Editor, History, Song, SongLink, Stats, Word
@@ -26,6 +28,14 @@ class AuthorModelTest(TestCase):
         Author.objects.create(name="重複作者")
         with self.assertRaises(IntegrityError):
             Author.objects.create(name="重複作者")
+
+    @unittest.skipUnless(connection.vendor == "mysql", "Strict ModeはMySQL固有の設定のため")
+    def test_mysql_strict_mode_rejects_max_length_overflow(self):
+        """#1091: Strict Modeが有効な場合、max_length超過の値はDBレベルでDataErrorになること
+        （無効だと警告のみでサイレントに切り詰められてしまい#593の移行時に実データで問題になった）"""
+        author = Author(name="あ" * 256)
+        with self.assertRaises(DataError):
+            author.save()
 
     def test_different_case_names_can_coexist(self):
         """一意制約はバイト完全一致で判定され、大文字小文字違いは別レコードとして許容される（#1092）"""


### PR DESCRIPTION
## Summary
- #1091で報告した、PythonAnywhereの本番MySQLでStrict Modeが有効になっていない問題を修正
- `config/settings.py`のMySQL用`OPTIONS`に`init_command`を追加し、接続時に`STRICT_TRANS_TABLES`を明示的に有効化
- 既存の`sql_mode`（環境によって異なる。ローカルは元々`STRICT_TRANS_TABLES`持ち、本番は`NO_ENGINE_SUBSTITUTION`のみ）を上書きしないよう、`SET sql_mode='...'`ではなく`CONCAT(@@sql_mode, ',STRICT_TRANS_TABLES')`で追加する形にした

## Test plan
- [x] `python manage.py check`でW002警告（Strict Mode未設定）が解消されることを確認
- [x] 接続後の`SELECT @@SESSION.sql_mode`で`STRICT_TRANS_TABLES`が含まれ、かつ既存のモード（`NO_ENGINE_SUBSTITUTION`等）が失われていないことを確認
- [x] ローカルMySQL・SQLite双方で `python manage.py test subekashi.tests article.tests`（932件）がPASS

Closes #1091

🤖 Generated with [Claude Code](https://claude.com/claude-code)