### PR TITLE
総合統計ページの月次グラフ、選択月ハイライトの色を緑に変更

### DIFF
--- a/subekashi/static/subekashi/js/stats.js
+++ b/subekashi/static/subekashi/js/stats.js
@@ -7,7 +7,7 @@ if (statsChartCanvas) {
     const BAR_COLOR = "rgba(54, 162, 235, 0.5)";
     // year・month両方指定時はグラフ側はmonthを無視してその年全体を表示するため、
     // 選択していた月の棒だけ色を変えて元のフィルターとの対応が分かるようにする（コードレビュー指摘対応）
-    const HIGHLIGHT_BAR_COLOR = "rgba(255, 99, 132, 0.7)";
+    const HIGHLIGHT_BAR_COLOR = "rgba(34, 197, 94, 0.8)";
 
     const SERIES_LABELS = {
         song_count: "曲数",


### PR DESCRIPTION
## 概要

総合統計ページの月次グラフで、`year`・`month`を両方指定した際に選択していた月の棒をハイライトする色を、赤から緑に変更する。

## Test plan

- [x] `python manage.py test subekashi.tests article.tests` が全件パス（935件）
- [x] `python manage.py check` がクリーン
- [x] 実データでハイライト表示を確認済み

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
