### PR TITLE
統計ページの累積グラフ(折れ線)の色・サイズを調整（#1107）

### DIFF
--- a/subekashi/static/subekashi/js/stats.js
+++ b/subekashi/static/subekashi/js/stats.js
@@ -14,6 +14,12 @@ if (statsChartCanvas) {
     // 丸の拡大は期間(年月)を具体的に指定した時のみ、全てのポイントに適用する
     const HIGHLIGHTED_POINT_RADIUS = 6;
 
+    // 棒(bar)の色・折れ線のポイント色はどちらも「該当月だけハイライト色、それ以外は通常色」で
+    // 共通のため、1つのヘルパーに集約する（コードレビュー指摘対応: 同じ式が2箇所に重複していた）
+    function colorForMonth(row) {
+        return row.month === highlightedMonth ? HIGHLIGHT_BAR_COLOR : BAR_COLOR;
+    }
+
     const SERIES_LABELS = {
         song_count: "曲数",
         total_view: "総再生回数",
@@ -36,20 +42,18 @@ if (statsChartCanvas) {
         const dataKey = chartMode === "monthly" ? `${seriesKey}_delta` : seriesKey;
 
         const isBar = chartMode === "monthly";
-        const backgroundColor = isBar
-            ? monthlyStats.map(row => row.month === highlightedMonth ? HIGHLIGHT_BAR_COLOR : BAR_COLOR)
-            : BAR_COLOR;
 
         const dataset = {
             label: SERIES_LABELS[seriesKey],
             data: monthlyStats.map(row => row[dataKey]),
-            backgroundColor: backgroundColor,
         };
-        if (!isBar) {
+        if (isBar) {
+            dataset.backgroundColor = monthlyStats.map(colorForMonth);
+        } else {
             // 累積グラフ(折れ線)は線を白系にし、期間(年月)を具体的に指定した時のみ
             // 全てのポイントを大きくしつつ、該当月のポイントだけ棒グラフと同じ緑系色にする（#1107）
             dataset.borderColor = LINE_COLOR;
-            dataset.pointBackgroundColor = monthlyStats.map(row => row.month === highlightedMonth ? HIGHLIGHT_BAR_COLOR : BAR_COLOR);
+            dataset.pointBackgroundColor = monthlyStats.map(colorForMonth);
             const pointRadius = highlightedMonth !== null ? HIGHLIGHTED_POINT_RADIUS : POINT_RADIUS;
             dataset.pointRadius = pointRadius;
             dataset.pointHoverRadius = pointRadius + 2;

--- a/subekashi/static/subekashi/js/stats.js
+++ b/subekashi/static/subekashi/js/stats.js
@@ -8,6 +8,11 @@ if (statsChartCanvas) {
     // year・month両方指定時はグラフ側はmonthを無視してその年全体を表示するため、
     // 選択していた月の棒だけ色を変えて元のフィルターとの対応が分かるようにする（コードレビュー指摘対応）
     const HIGHLIGHT_BAR_COLOR = "rgba(34, 197, 94, 0.8)";
+    // 累積グラフ(折れ線)の線・ポイントの色・サイズ（#1107）
+    const LINE_COLOR = "rgba(255, 255, 255, 0.8)";
+    const POINT_RADIUS = 3;
+    // 丸の拡大は期間(年月)を具体的に指定した時のみ、全てのポイントに適用する
+    const HIGHLIGHTED_POINT_RADIUS = 6;
 
     const SERIES_LABELS = {
         song_count: "曲数",
@@ -35,6 +40,21 @@ if (statsChartCanvas) {
             ? monthlyStats.map(row => row.month === highlightedMonth ? HIGHLIGHT_BAR_COLOR : BAR_COLOR)
             : BAR_COLOR;
 
+        const dataset = {
+            label: SERIES_LABELS[seriesKey],
+            data: monthlyStats.map(row => row[dataKey]),
+            backgroundColor: backgroundColor,
+        };
+        if (!isBar) {
+            // 累積グラフ(折れ線)は線を白系にし、期間(年月)を具体的に指定した時のみ
+            // 全てのポイントを大きくしつつ、該当月のポイントだけ棒グラフと同じ緑系色にする（#1107）
+            dataset.borderColor = LINE_COLOR;
+            dataset.pointBackgroundColor = monthlyStats.map(row => row.month === highlightedMonth ? HIGHLIGHT_BAR_COLOR : BAR_COLOR);
+            const pointRadius = highlightedMonth !== null ? HIGHLIGHTED_POINT_RADIUS : POINT_RADIUS;
+            dataset.pointRadius = pointRadius;
+            dataset.pointHoverRadius = pointRadius + 2;
+        }
+
         if (chart) {
             chart.destroy();
         }
@@ -42,11 +62,7 @@ if (statsChartCanvas) {
             type: isBar ? "bar" : "line",
             data: {
                 labels: labels,
-                datasets: [{
-                    label: SERIES_LABELS[seriesKey],
-                    data: monthlyStats.map(row => row[dataKey]),
-                    backgroundColor: backgroundColor,
-                }],
+                datasets: [dataset],
             },
             options: {
                 responsive: true,


### PR DESCRIPTION
## Summary
- `subekashi/static/subekashi/js/stats.js`の累積グラフ(折れ線)について、線の色を白系(`rgba(255, 255, 255, 0.8)`)に変更
- 期間(年月)を具体的に指定した時のみ、全てのポイントを大きく(3px→6px)する。指定が無い場合は従来通りの小さいサイズ
- ポイントの色は棒グラフと同様、該当月のみ緑系(`HIGHLIGHT_BAR_COLOR`)、それ以外は青系(`BAR_COLOR`)のまま
- 棒グラフ(月ごと表示)側は変更なし

Closes #1107

## Test plan
- [x] devサーバー上でPlaywrightにより実際の画面を確認
  - 期間指定なし: 白い線・小さい丸(全て青系)
  - 期間指定あり(2020年5月): 白い線・全て大きい丸、該当月(2020/5)のみ緑系
  - 棒グラフ(月ごと)表示に影響が無いことを確認
  - コンソールエラー無し
- クライアントサイドJSのみの変更のため、Pythonテストスイートに影響なし（`python manage.py test subekashi.tests article.tests`は本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)