### PR TITLE
統計ページの累積グラフのcanvasが縮小後に元のサイズへ戻らない不具合を修正（#1110）

### DIFF
--- a/subekashi/static/subekashi/js/stats.js
+++ b/subekashi/static/subekashi/js/stats.js
@@ -82,10 +82,27 @@ if (statsChartCanvas) {
     // canvasのサイズが元に戻らない不具合があるため（#1110）、自前でコンテナのサイズ変化を
     // 監視し、明示的にresize()を呼び出すことで追従させる。Chart.js自身の内部処理と
     // 同一フレーム内で競合すると古いサイズに巻き戻されるため、rAFを2回はさんで
-    // 内部処理が完全に収まった後に呼び出す
+    // 内部処理が完全に収まった後に呼び出す（options.resizeDelayでは今回の問題は
+    // 解消しないことを確認済み。縮小方向は追従するが拡大方向のみ追従しないという
+    // 非対称な不具合のため、単純なデバウンスでは直らない）
+    //
+    // resizeScheduledは、ドラッグ操作等でResizeObserverが連続発火した際に
+    // 二重rAFコールバックが多重に積み上がるのを防ぐガード（コードレビュー指摘対応）。
+    // chart?.resize()は、将来renderChartの非同期化等でこのコールバック実行時に
+    // chartが未生成/破棄済みになるケースに備えた防御的な書き方（コードレビュー指摘対応）。
+    // このスクリプトはフルページロードの度に1回だけ実行される前提のため、
+    // ResizeObserverのdisconnect()は行っていない
+    let resizeScheduled = false;
     new ResizeObserver(() => {
+        if (resizeScheduled) {
+            return;
+        }
+        resizeScheduled = true;
         requestAnimationFrame(() => {
-            requestAnimationFrame(() => chart.resize());
+            requestAnimationFrame(() => {
+                chart?.resize();
+                resizeScheduled = false;
+            });
         });
     }).observe(document.getElementById("stats-chart-wrapper"));
 

--- a/subekashi/static/subekashi/js/stats.js
+++ b/subekashi/static/subekashi/js/stats.js
@@ -78,6 +78,17 @@ if (statsChartCanvas) {
 
     renderChart();
 
+    // Chart.jsの組み込みresponsive自動追従は、コンテナが一度縮小した後に再び拡大した際、
+    // canvasのサイズが元に戻らない不具合があるため（#1110）、自前でコンテナのサイズ変化を
+    // 監視し、明示的にresize()を呼び出すことで追従させる。Chart.js自身の内部処理と
+    // 同一フレーム内で競合すると古いサイズに巻き戻されるため、rAFを2回はさんで
+    // 内部処理が完全に収まった後に呼び出す
+    new ResizeObserver(() => {
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => chart.resize());
+        });
+    }).observe(document.getElementById("stats-chart-wrapper"));
+
     document.querySelectorAll('input[name="chart-mode"], input[name="chart-series"]').forEach(radio => {
         radio.addEventListener("change", () => {
             if (radio.checked) {


### PR DESCRIPTION
## Summary
- `/stats/`の`#stats-chart`(Chart.jsのcanvas)について、コンテナ幅を一度縮めてから元に戻しても、canvasが縮んだサイズのまま復帰しない不具合を修正
- 原因: Chart.jsの組み込み`responsive: true`による自動リサイズ検知が、コンテナが**縮小**する方向は正しく追従するが、**拡大**する方向では追従しない非対称な挙動だった（検証済み）
- 対応: `#stats-chart-wrapper`を監視する`ResizeObserver`を自前で設置し、明示的に`chart.resize()`を呼び出す。ただし単純にResizeObserverのコールバックから直接`resize()`を呼ぶと、Chart.js自身の内部リサイズ処理と同一フレーム内で競合し、古い(縮んだ)サイズに巻き戻されるケースが再現したため、`requestAnimationFrame`を2回はさんでChart.jsの内部処理が完全に収まった後に呼び出すようにした
- レビュー対応: ResizeObserverが連続発火した際に二重rAFコールバックが積み上がらないようデバウンスガード(`resizeScheduled`)を追加、`chart?.resize()`による防御的呼び出しに変更、ResizeObserverを`disconnect()`していない理由（フルページロード前提）をコメントで明記

### 検討した代替案: `options.resizeDelay`
Chart.js 4.xの`resizeDelay`（リサイズ処理のデバウンス、デフォルト0）を試しましたが、今回の問題は解消しませんでした。今回の不具合はデバウンス不足ではなく「縮小方向は追従するが拡大方向のみ追従しない」という非対称な検知漏れが原因のため、単純な待ち時間の調整では直らないことを確認済みです。そのため、自前でリサイズを検知して明示的に`resize()`を呼び出す方式にしています。

Closes #1110

## Test plan
- [x] devサーバー上でPlaywrightにより、`#stats-chart-wrapper`の幅を縮小→拡大を複数回繰り返し、毎回正しく元のサイズ(800x400)に復帰することを確認
- [x] グラフモード(月ごと/累積)切り替え（内部でChart.jsのdestroy+再生成が発生）を挟んでも、縮小→拡大への追従が引き続き機能することを確認
- [x] `resizeDelay`単体では拡大方向への追従漏れが解消しないことを確認
- [x] ドラッグ操作を模した高頻度の連続リサイズ（待ち時間なしで31段階の幅変更を発火）でも、`resize()`の実呼び出し回数が数回に収まり（デバウンスが機能）、最終的なサイズも正しくなることを確認
- [x] コンソールエラーが出ていないことを確認
- [x] `python manage.py test subekashi.tests article.tests` で全936件成功（クライアントサイドJSのみの変更のため無関係だが念のため確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)