### PR TITLE
統計ページ: songrange/年月変更後もグラフの表示設定を維持する（#1111）

### DIFF
--- a/subekashi/static/subekashi/js/stats.js
+++ b/subekashi/static/subekashi/js/stats.js
@@ -106,9 +106,20 @@ if (statsChartCanvas) {
         });
     }).observe(document.getElementById("stats-chart-wrapper"));
 
+    // グラフ表示設定(chart-mode/chart-series)はsongrange/year/month用のformとは別扱いのため、
+    // ページ全体の再読み込みを挟むと消えてしまう。選択変更時にcookieへ保存しておき、
+    // 次回アクセス時にサーバー側(StatsView)がcookieを読んで初期状態に反映する（#1111）
+    const CHART_SETTING_COOKIE_NAMES = {
+        "chart-mode": "stats_chart_mode",
+        "chart-series": "stats_chart_series",
+    };
+    const CHART_SETTING_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1年（サーバー側のLONG_TERM_COOKIE_AGEと合わせる）
+
     document.querySelectorAll('input[name="chart-mode"], input[name="chart-series"]').forEach(radio => {
         radio.addEventListener("change", () => {
             if (radio.checked) {
+                const cookieName = CHART_SETTING_COOKIE_NAMES[radio.name];
+                document.cookie = `${cookieName}=${radio.value}; path=/; max-age=${CHART_SETTING_COOKIE_MAX_AGE}; samesite=lax`;
                 renderChart();
             }
         });

--- a/subekashi/static/subekashi/js/stats.js
+++ b/subekashi/static/subekashi/js/stats.js
@@ -2,6 +2,7 @@ const statsChartCanvas = document.getElementById("stats-chart");
 if (statsChartCanvas) {
     const monthlyStats = JSON.parse(document.getElementById("monthly-stats-data").textContent);
     const highlightedMonth = JSON.parse(document.getElementById("highlighted-month-data").textContent);
+    const chartSettingsCookieConfig = JSON.parse(document.getElementById("chart-settings-cookie-config").textContent);
     const labels = monthlyStats.map(row => `${row.year}/${row.month}`);
 
     const BAR_COLOR = "rgba(54, 162, 235, 0.5)";
@@ -108,18 +109,14 @@ if (statsChartCanvas) {
 
     // グラフ表示設定(chart-mode/chart-series)はsongrange/year/month用のformとは別扱いのため、
     // ページ全体の再読み込みを挟むと消えてしまう。選択変更時にcookieへ保存しておき、
-    // 次回アクセス時にサーバー側(StatsView)がcookieを読んで初期状態に反映する（#1111）
-    const CHART_SETTING_COOKIE_NAMES = {
-        "chart-mode": "stats_chart_mode",
-        "chart-series": "stats_chart_series",
-    };
-    const CHART_SETTING_COOKIE_MAX_AGE = 60 * 60 * 24 * 365; // 1年（サーバー側のLONG_TERM_COOKIE_AGEと合わせる）
-
+    // 次回アクセス時にサーバー側(StatsView)がcookieを読んで初期状態に反映する（#1111）。
+    // cookie名・有効期限はサーバー側とのハードコードの二重管理を避けるため、
+    // chartSettingsCookieConfig(StatsViewがcontext経由で渡す)を参照する（コードレビュー指摘対応）
     document.querySelectorAll('input[name="chart-mode"], input[name="chart-series"]').forEach(radio => {
         radio.addEventListener("change", () => {
             if (radio.checked) {
-                const cookieName = CHART_SETTING_COOKIE_NAMES[radio.name];
-                document.cookie = `${cookieName}=${radio.value}; path=/; max-age=${CHART_SETTING_COOKIE_MAX_AGE}; samesite=lax`;
+                const cookieName = chartSettingsCookieConfig.names[radio.name];
+                document.cookie = `${cookieName}=${radio.value}; path=/; max-age=${chartSettingsCookieConfig.max_age}; samesite=lax`;
                 renderChart();
             }
         });

--- a/subekashi/templates/subekashi/stats.html
+++ b/subekashi/templates/subekashi/stats.html
@@ -12,21 +12,21 @@
 
     {% if monthly_stats %}
         <div class="range-radio-group">
-            <input type="radio" id="chart-mode-monthly" name="chart-mode" value="monthly" checked>
+            <input type="radio" id="chart-mode-monthly" name="chart-mode" value="monthly" {% if chart_mode == "monthly" %}checked{% endif %}>
             <label for="chart-mode-monthly">月ごと</label>
-            <input type="radio" id="chart-mode-cumulative" name="chart-mode" value="cumulative">
+            <input type="radio" id="chart-mode-cumulative" name="chart-mode" value="cumulative" {% if chart_mode == "cumulative" %}checked{% endif %}>
             <label for="chart-mode-cumulative">累積</label>
         </div>
         <div class="range-radio-group">
-            <input type="radio" id="chart-series-song_count" name="chart-series" value="song_count" checked>
+            <input type="radio" id="chart-series-song_count" name="chart-series" value="song_count" {% if chart_series == "song_count" %}checked{% endif %}>
             <label for="chart-series-song_count">曲数</label>
-            <input type="radio" id="chart-series-total_view" name="chart-series" value="total_view">
+            <input type="radio" id="chart-series-total_view" name="chart-series" value="total_view" {% if chart_series == "total_view" %}checked{% endif %}>
             <label for="chart-series-total_view">総再生回数</label>
-            <input type="radio" id="chart-series-total_like" name="chart-series" value="total_like">
+            <input type="radio" id="chart-series-total_like" name="chart-series" value="total_like" {% if chart_series == "total_like" %}checked{% endif %}>
             <label for="chart-series-total_like">総高評価数</label>
-            <input type="radio" id="chart-series-total_authors" name="chart-series" value="total_authors">
+            <input type="radio" id="chart-series-total_authors" name="chart-series" value="total_authors" {% if chart_series == "total_authors" %}checked{% endif %}>
             <label for="chart-series-total_authors">総作者数</label>
-            <input type="radio" id="chart-series-total_imitateds" name="chart-series" value="total_imitateds">
+            <input type="radio" id="chart-series-total_imitateds" name="chart-series" value="total_imitateds" {% if chart_series == "total_imitateds" %}checked{% endif %}>
             <label for="chart-series-total_imitateds">総模倣曲関係数</label>
         </div>
         <div id="stats-chart-wrapper">

--- a/subekashi/templates/subekashi/stats.html
+++ b/subekashi/templates/subekashi/stats.html
@@ -34,6 +34,7 @@
         </div>
         {{ monthly_stats|json_script:"monthly-stats-data" }}
         {{ highlighted_month|json_script:"highlighted-month-data" }}
+        {{ chart_settings_cookie_config|json_script:"chart-settings-cookie-config" }}
     {% endif %}
 </section>
 {% endblock %}

--- a/subekashi/tests/TEST_PLAN_UNIT.md
+++ b/subekashi/tests/TEST_PLAN_UNIT.md
@@ -738,7 +738,7 @@ DBアクセス（候補・衝突チェック）を伴うため `TestCase` を使
 | フォールバック時もレガシーgenetype="model"は対象外 | 未評価janomeが0件で、評価済みの`genetype="model"`レコードが存在 | フォールバックしても表示されない |
 | トークンのspan間に空白を挟まない（#1081） | Word候補がある単語を含む歌詞 | `.lyric`内の`</span>`と`<span>`の間に空白文字が入らない（「最高の行をコピー」でinnerTextをコピーした際に単語同士が連結され、余分なスペースが入らないようにするため） |
 
-#### 7-14. `StatsView` (`/stats/`)（#334）
+#### 7-14. `StatsView` (`/stats/`)（#334。グラフ表示設定のcookie保持、#1111）
 
 | テストケース | 条件 | 期待結果 |
 | --- | --- | --- |
@@ -767,6 +767,10 @@ DBアクセス（候補・衝突チェック）を伴うため `TestCase` を使
 | `highlighted_month`はyearのみ指定時はNone | `?year=2024`（monthは指定しない） | `context["highlighted_month"]`が`None` |
 | `highlighted_month`はmonthのみ指定時もNone | `?month=1`（yearは指定しない） | `context["highlighted_month"]`が`None` |
 | `highlighted_month`はyear・month両方指定時のみセット（コードレビュー指摘対応） | `?year=2024&month=6` | `context["highlighted_month"]`が`6`になり、JS側で棒グラフのその月だけ色を変えるための`highlighted-month-data`が埋め込まれる（グラフ側はmonthを無視してその年全体を表示するため、選択していた月をハイライトして元のフィルターとの対応を分かりやすくする） |
+| グラフ表示設定はcookie未設定時デフォルト（#1111） | cookie無し | `context["chart_mode"]`が`"monthly"`、`context["chart_series"]`が`"song_count"`になり、対応するラジオボタンに`checked`が付く |
+| グラフ表示設定はcookieの値を反映（#1111） | `stats_chart_mode=cumulative`・`stats_chart_series=total_view`のcookieを送信 | `context["chart_mode"]`が`"cumulative"`、`context["chart_series"]`が`"total_view"`になり、対応するラジオボタンのみに`checked`が付く |
+| グラフ表示設定はsongrange変更（ページ全体の再読み込み）を挟んでも維持される（#1111の再現ケース） | `stats_chart_mode=cumulative`のcookieを送信した状態で`?songrange=subeana`にアクセス | `context["chart_mode"]`が`"cumulative"`のまま（`chart-mode`/`chart-series`は`songrange`/`year`/`month`用のformの外側にあり、これらの変更时のページ全体再読み込みでは送信されないため、cookie側で維持する） |
+| 不正なグラフ表示設定cookieはデフォルトにフォールバック（#1111） | `stats_chart_mode`/`stats_chart_series`に許可されていない値を送信 | `context["chart_mode"]`が`"monthly"`、`context["chart_series"]`が`"song_count"`にフォールバックする |
 
 #### 7-15. `AuthorStatsView` (`/authors/<id>/stats/`)（#334）
 

--- a/subekashi/tests/test_views.py
+++ b/subekashi/tests/test_views.py
@@ -972,6 +972,69 @@ class StatsViewTest(TestCase):
         self.assertIsNone(response.context["kenreki"]["overflow_color"])
         self.assertNotContains(response, "style=\"color: hsl(")
 
+    @staticmethod
+    def _is_radio_checked(response, radio_id):
+        match = re.search(rf'<input[^>]*id="{radio_id}"[^>]*>', response.content.decode())
+        assert match is not None, f'{radio_id} not found in response'
+        return "checked" in match.group(0)
+
+    def _create_all_songrange_stats(self):
+        # monthly_statsが存在しないとchart-mode/chart-seriesのラジオボタン自体が
+        # 描画されないため、Statsレコードを用意する。また、songrangeは実在するSongの
+        # 種類に応じてresolve_songrange()が自動選択するため、"全て"が選ばれるよう
+        # is_subeana=True/False両方のSongも用意する
+        Song.objects.create(title="すべあな曲", is_subeana=True)
+        Song.objects.create(title="界隈外曲", is_subeana=False)
+        Stats.objects.create(year=2024, month=1, songrange="all", song_count=2)
+
+    def test_chart_settings_default_when_no_cookie(self):
+        # #1111: cookie未設定時は月ごと/曲数がデフォルトで選択される
+        self._create_all_songrange_stats()
+
+        response = self.client.get(reverse("subekashi:stats"))
+
+        self.assertEqual(response.context["chart_mode"], "monthly")
+        self.assertEqual(response.context["chart_series"], "song_count")
+        self.assertTrue(self._is_radio_checked(response, "chart-mode-monthly"))
+        self.assertFalse(self._is_radio_checked(response, "chart-mode-cumulative"))
+        self.assertTrue(self._is_radio_checked(response, "chart-series-song_count"))
+
+    def test_chart_settings_reflect_cookie_values(self):
+        # #1111: songrange/year/month用のformとは別に、グラフ表示設定はcookieで
+        # 引き継がれる（stats.js側がchart-mode/chart-series変更時にcookieへ保存する）
+        self._create_all_songrange_stats()
+        self.client.cookies["stats_chart_mode"] = "cumulative"
+        self.client.cookies["stats_chart_series"] = "total_view"
+
+        response = self.client.get(reverse("subekashi:stats"))
+
+        self.assertEqual(response.context["chart_mode"], "cumulative")
+        self.assertEqual(response.context["chart_series"], "total_view")
+        self.assertTrue(self._is_radio_checked(response, "chart-mode-cumulative"))
+        self.assertFalse(self._is_radio_checked(response, "chart-mode-monthly"))
+        self.assertTrue(self._is_radio_checked(response, "chart-series-total_view"))
+        self.assertFalse(self._is_radio_checked(response, "chart-series-song_count"))
+
+    def test_chart_settings_reflect_cookie_across_songrange_filter_change(self):
+        # #1111の再現ケース: songrange変更（ページ全体の再読み込み相当）を挟んでも
+        # グラフ表示設定(cookie)が維持されること
+        self.client.cookies["stats_chart_mode"] = "cumulative"
+        Song.objects.create(title="すべあな曲", is_subeana=True)
+
+        response = self.client.get(reverse("subekashi:stats"), {"songrange": "subeana"})
+
+        self.assertEqual(response.context["chart_mode"], "cumulative")
+
+    def test_invalid_chart_settings_cookie_falls_back_to_default(self):
+        # 不正なcookie値（改ざん・旧バージョンの値等）はデフォルトにフォールバックする
+        self.client.cookies["stats_chart_mode"] = "invalid-value"
+        self.client.cookies["stats_chart_series"] = "invalid-value"
+
+        response = self.client.get(reverse("subekashi:stats"))
+
+        self.assertEqual(response.context["chart_mode"], "monthly")
+        self.assertEqual(response.context["chart_series"], "song_count")
+
 
 @override_settings(STORAGES=STATIC_STORAGE)
 class AuthorStatsViewTest(TestCase):

--- a/subekashi/tests/test_views.py
+++ b/subekashi/tests/test_views.py
@@ -974,6 +974,8 @@ class StatsViewTest(TestCase):
 
     @staticmethod
     def _is_radio_checked(response, radio_id):
+        # stats.htmlは各<input>を1行で出力する前提のパターン（re.DOTALL無し）。
+        # 将来templateが複数行に変わった場合はこのヘルパーも合わせて見直すこと（コードレビュー指摘対応）
         match = re.search(rf'<input[^>]*id="{radio_id}"[^>]*>', response.content.decode())
         assert match is not None, f'{radio_id} not found in response'
         return "checked" in match.group(0)

--- a/subekashi/views/stats.py
+++ b/subekashi/views/stats.py
@@ -1,5 +1,6 @@
 from django.shortcuts import render
 from django.views import View
+from subekashi.constants.constants import LONG_TERM_COOKIE_AGE
 from subekashi.lib.kenreki_service import compute_kenreki_for_songs
 from subekashi.lib.stats_service import (
     apply_songrange_filter,
@@ -24,6 +25,13 @@ CHART_MODE_DEFAULT = "monthly"
 CHART_SERIES_COOKIE = "stats_chart_series"
 CHART_SERIES_CHOICES = {"song_count", "total_view", "total_like", "total_authors", "total_imitateds"}
 CHART_SERIES_DEFAULT = "song_count"
+
+# stats.js側もこのcookie名・有効期限を使ってdocument.cookieに書き込む必要があるため、
+# ハードコードを二重管理せずcontext経由でJSに渡す（コードレビュー指摘対応）
+CHART_SETTINGS_COOKIE_CONFIG = {
+    "names": {"chart-mode": CHART_MODE_COOKIE, "chart-series": CHART_SERIES_COOKIE},
+    "max_age": LONG_TERM_COOKIE_AGE,
+}
 
 
 class StatsView(View):
@@ -85,6 +93,7 @@ class StatsView(View):
             "highlighted_month": highlighted_month,
             "chart_mode": chart_mode,
             "chart_series": chart_series,
+            "chart_settings_cookie_config": CHART_SETTINGS_COOKIE_CONFIG,
             "description": "すべかしに登録された曲の統計情報。",
         }
         return render(request, "subekashi/stats.html", context)

--- a/subekashi/views/stats.py
+++ b/subekashi/views/stats.py
@@ -14,6 +14,17 @@ from subekashi.lib.stats_service import (
 )
 from subekashi.models import Song, Stats
 
+# グラフ表示設定のcookie名・許容値・デフォルト値。cookie自体はstats.js側で
+# document.cookieに直接書き込む（songrange/year/month用のformとは別扱いのため、
+# ページ全体の再読み込みを挟んでも設定が消えないよう、選択変更時にcookieへ保存する。#1111）
+CHART_MODE_COOKIE = "stats_chart_mode"
+CHART_MODE_CHOICES = {"monthly", "cumulative"}
+CHART_MODE_DEFAULT = "monthly"
+
+CHART_SERIES_COOKIE = "stats_chart_series"
+CHART_SERIES_CHOICES = {"song_count", "total_view", "total_like", "total_authors", "total_imitateds"}
+CHART_SERIES_DEFAULT = "song_count"
+
 
 class StatsView(View):
     def get(self, request):
@@ -52,6 +63,14 @@ class StatsView(View):
         # 選択していた月のみ棒の色を変えて分かりやすくする
         highlighted_month = int(month) if year != "all" and month != "all" else None
 
+        chart_mode = request.COOKIES.get(CHART_MODE_COOKIE, CHART_MODE_DEFAULT)
+        if chart_mode not in CHART_MODE_CHOICES:
+            chart_mode = CHART_MODE_DEFAULT
+
+        chart_series = request.COOKIES.get(CHART_SERIES_COOKIE, CHART_SERIES_DEFAULT)
+        if chart_series not in CHART_SERIES_CHOICES:
+            chart_series = CHART_SERIES_DEFAULT
+
         context = {
             "metatitle": "統計",
             "songrange": songrange,
@@ -64,6 +83,8 @@ class StatsView(View):
             "kenreki": kenreki,
             "monthly_stats": monthly_stats,
             "highlighted_month": highlighted_month,
+            "chart_mode": chart_mode,
+            "chart_series": chart_series,
             "description": "すべかしに登録された曲の統計情報。",
         }
         return render(request, "subekashi/stats.html", context)


### PR DESCRIPTION
## Summary
- `/stats/`で界隈曲の種類(songrange)や年・月を変更すると、グラフの表示設定（「月ごと/累積」・「曲数/総再生回数/...」）が初期値にリセットされる不具合を修正
- 原因: `chart-mode`/`chart-series`のラジオボタンは、songrange/year/monthを扱う`<form id="stats-filter">`の外側にあり、`checked`も常に固定値だった。songrange/year/monthの変更は`onchange="this.form.submit()"`でページ全体を再読み込みするため、その際にグラフ表示設定はブラウザ上のJS状態ごと失われていた
- 対応: `stats.js`側でラジオボタン変更時に`document.cookie`へ直接保存し（既存の`views/songs.py`のsongrange/sort等のcookie保持パターンを参考に、GET/POSTのform round-tripは追加せずcookieのみで完結させる軽量な実装）、`StatsView`側で`request.COOKIES`から読み取って`chart_mode`/`chart_series`をcontextに渡し、テンプレートの`checked`属性を動的に決定するようにした
- 不正なcookie値は`monthly`/`song_count`にフォールバックする

Closes #1111

## レビュー対応
- cookie名・有効期限がJS(`stats.js`)とPython(`views/stats.py`)の双方にハードコードされ二重管理になっていた点を解消。`StatsView`側の`CHART_SETTINGS_COOKIE_CONFIG`（cookie名・`LONG_TERM_COOKIE_AGE`）を単一の情報源とし、`json_script`でテンプレート経由でJSに渡すよう変更（`stats.js`は`chartSettingsCookieConfig`を参照するのみ）
- テストの`_is_radio_checked()`ヘルパーが、templateが各`<input>`を1行で出力する前提（`re.DOTALL`無し）であることをコメントで明記

## Test plan
- [x] `subekashi/tests/test_views.py`の`StatsViewTest`に、cookie未設定時のデフォルト・cookie値の反映・songrange変更（フルページ再読み込み相当）を挟んだ維持・不正なcookie値のフォールバックを検証するテストを追加
- [x] devサーバー上でPlaywrightにより、累積/総再生回数に切り替え→songrange変更（実際のフルページ再読み込み）を経ても設定が維持されることを実機確認（レビュー対応後も再確認済み、cookie有効期限が`LONG_TERM_COOKIE_AGE`と一致する`31536000`になっていることも確認）
- [x] `python manage.py test subekashi.tests article.tests` で全940件成功
- [x] `subekashi/tests/TEST_PLAN_UNIT.md`を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)